### PR TITLE
added predefined curves

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,8 @@ name: Noir tests
 
 on:
   push:
-   branches:
-    - main
+    branches:
+      - main
   pull_request:
 
 env:
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [nightly, 0.34.0]
+        toolchain: [nightly, 0.35.0]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 0.34.0
+          toolchain: 0.35.0
 
       - name: Run formatter
         run: nargo fmt --check

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -2,7 +2,9 @@
 name = "noir_bigcurve"
 type = "lib"
 authors = [""]
-compiler_version = ">=0.34.0"
+compiler_version = ">=0.35.0"
 
 [dependencies]
-bignum = {tag = "v0.3.4", git = "https://github.com/noir-lang/noir-bignum"}
+bignum = {tag = "zw/modular_square_root_and_constrained_derive_from_seed", git = "https://github.com/noir-lang/noir-bignum"}
+# bignum = {path = "../noir-bignum"}
+sort = {tag = "v0.1.0", git = "https://github.com/noir-lang/noir_sort"}

--- a/src/bigcurve_test.nr
+++ b/src/bigcurve_test.nr
@@ -1,7 +1,6 @@
 use dep::bignum::BigNum;
 
 use crate::BigCurve;
-use crate::CurveParamsTrait;
 
 use crate::curve_jac;
 use crate::curve_jac::JTranscript;
@@ -9,46 +8,10 @@ use crate::curve_jac::AffineTranscript;
 use crate::curve_jac::CurveJ;
 use crate::scalar_field::ScalarField;
 use crate::PointTable;
-
-use dep::bignum::fields::bn254Fq::BNParams as BNParams;
-
+use crate::utils::hash_to_curve::hash_to_curve;
+use crate::curves::bn254::{BN254, BN254Scalar, BN254Params};
 type Fq = BigNum<3, BNParams>;
 
-struct BN254Params {
-}
-impl CurveParamsTrait<BigNum<3, BNParams>> for BN254Params {
-    fn one() -> [BigNum<3, BNParams>; 2] {
-        let mut one: Fq = BigNum::new();
-        one.limbs[0] = 1;
-        let mut two = one;
-        two.limbs[0] = 2;
-        [one, two]
-    }
-
-    fn offset_generator() -> [BigNum<3, BNParams>; 2] {
-        [
-            BigNum { limbs: [0xf30f376a22bd3695abf4dcdfed66c6, 0x80d7bbcaebb13bbabfc30184f59912, 0x0cfb] },
-            BigNum { limbs: [0xe53572d644c1e06f80ab52ef02fa2f, 0xa40d9e20debde026e47f8bfc4d3c41, 0x07f6] }
-        ]
-    }
-
-    fn offset_generator_final() -> [BigNum<3, BNParams>; 2] {
-        [
-            BigNum { limbs: [0x0b672a3489895d47157f096e077348, 0x29f5f5b786660171ae9ad36f6db594, 0x15f1] },
-            BigNum { limbs: [0x6e4553aa3ae998fcd27ca8a17188ef, 0xb3193f7f0a731913174831ca905feb, 0x21ff] }
-        ]
-    }
-
-    fn b() -> BigNum<3, BNParams> {
-        BigNum { limbs: [3, 0, 0] }
-    }
-
-    fn a() -> BigNum<3, BNParams> {
-        BigNum { limbs: [0, 0, 0] }
-    }
-}
-
-type BN254 = BigCurve<Fq, BN254Params>;
 type BN254J = CurveJ<Fq, BN254Params>;
 
 fn main(x: Field) {
@@ -78,26 +41,6 @@ fn main(x: Field) {
         }
         A = A.double_with_hint(transcript[i]);
     }
-    // println(f"{A}");
-    // let result = P.mul_with_hint(scalar, transcript);
-    // // -2
-    // let mut expected: BN254 = BigCurve {
-    //     x: BigNum { limbs: [0x7816a916871ca8d3c208c16d87cfd3, 0x44e72e131a029b85045b68181585d9, 0x0306] },
-    //     y: BigNum { limbs: [0xa6a449e3538fc7ff3ebf7a5a18a2c4, 0x738c0e0a7c92e7845f96b2ae9c0a68, 0x15ed] }
-    // };
-    // expected.y = BigNum::new() - expected.y;
-    // assert(result == expected);
-    // let scalar2: ScalarField<64> = ScalarField::from(x * x); // p - 2 ? 
-    // let transcript2 = get_transcript(CurveJ { x: Q.x, y: Q.y, z: BigNum::one() }, scalar);
-    // let result = Q.mul_with_hint(scalar2, transcript2);
-    // // -2
-    // let mut expected: BN254 = BigCurve {
-    //     x: BigNum { limbs: [0x7816a916871ca8d3c208c16d87cfd3, 0x44e72e131a029b85045b68181585d9, 0x0306] },
-    //     y: BigNum { limbs: [0xa6a449e3538fc7ff3ebf7a5a18a2c4, 0x738c0e0a7c92e7845f96b2ae9c0a68, 0x15ed] }
-    // };
-    // expected.y = BigNum::new() - expected.y;
-    // assert(result.x.eq(expected.x));
-    // assert(result.y.eq(expected.y));
 }
 
 unconstrained fn evaluate_mul(P: BN254J, scalar: ScalarField<64>, Q: BN254J, K: BN254J) -> bool {
@@ -119,9 +62,6 @@ unconstrained fn get_msm_transcript(
 unconstrained fn get_transcript(P: BN254J, scalar: ScalarField<64>) -> [AffineTranscript<Fq>; 326] {
     let res = P.mul(scalar);
     let transcript = res.1;
-    // println(f"let transcript: AffineTranscript<N, Params> = {transcript}");
-    // let ff = transcript.len();
-    // println(f"transcript len = {ff}");
     transcript.as_array()
 }
 
@@ -162,7 +102,6 @@ fn test_offset_foo() {
     };
 
     let R: BN254 = P.sub(Q);
-    // println(f"R = {R}");
     assert(R.is_infinity == true);
 }
 
@@ -179,8 +118,6 @@ fn test_mul_by_0() {
     };
 
     let result = P.mul_with_hint(scalar, transcript);
-    // println(f"RESULT = {result}");
-    // -2
     assert(result.is_infinity == true);
 }
 
@@ -195,49 +132,7 @@ fn test_mul_a_point_at_infinity() {
     };
 
     let result = P.mul_with_hint(scalar, transcript);
-    // println(f"RESULT = {result}");
-    // -2
     assert(result.is_infinity == true);
-}
-#[test]
-fn test_linear_expression() {
-    let One: BN254 = BigCurve::one();
-    let Two: BN254 = BigCurve {
-        x: BigNum { limbs: [0x7816a916871ca8d3c208c16d87cfd3, 0x44e72e131a029b85045b68181585d9, 0x0306] },
-        y: BigNum { limbs: [0xa6a449e3538fc7ff3ebf7a5a18a2c4, 0x738c0e0a7c92e7845f96b2ae9c0a68, 0x15ed] },
-        is_infinity: false
-    };
-
-    let p_minus_2 = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593efffffff; // p - 2
-    let p_minus_6 = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593effffffb; // p - 6
-    let scalar2: ScalarField<64> = ScalarField::from(p_minus_2);
-    let scalar6: ScalarField<64> = ScalarField::from(p_minus_6);
-    let expected = Two.neg();
-
-    let result = BigCurve::evaluate_linear_expression([One, Two.neg()], [scalar6, scalar2], []);
-    assert(result == expected);
-}
-
-#[test]
-fn test_msm() {
-    let One: BN254 = BigCurve::one();
-    let Two: BN254 = BigCurve {
-        x: BigNum { limbs: [0x7816a916871ca8d3c208c16d87cfd3, 0x44e72e131a029b85045b68181585d9, 0x0306] },
-        y: BigNum { limbs: [0xa6a449e3538fc7ff3ebf7a5a18a2c4, 0x738c0e0a7c92e7845f96b2ae9c0a68, 0x15ed] },
-        is_infinity: false
-    };
-
-    let p_minus_2 = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593efffffff; // p - 2
-    let p_minus_6 = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593effffffb; // p - 6
-    let scalar2: ScalarField<64> = ScalarField::from(p_minus_2);
-    let scalar6: ScalarField<64> = ScalarField::from(p_minus_6);
-
-    let transcript = unsafe {
-        get_msm_transcript(CurveJ::from(One), CurveJ::from(Two.neg()), scalar6, scalar2)
-    };
-    let result = BigCurve::msm_with_hint([One, Two.neg()], [scalar6, scalar2], transcript);
-    let expected = Two.neg();
-    assert(result == expected);
 }
 
 #[test]
@@ -295,281 +190,391 @@ fn test_add_dbl() {
 
 #[test]
 fn test_transcript() {
-    let P: BN254J = CurveJ::one();
+    unsafe {
+        let P: BN254J = CurveJ::one();
 
-    let P2 = unsafe {
-        P.dbl()
-    };
+        let P2 = unsafe {
+            P.dbl()
+        };
 
-    let Z_inverse = P2.1.z3.__invmod();
+        let Z_inverse = P2.1.z3.__invmod();
 
-    let lambda = P2.1.lambda_numerator.__mul(Z_inverse);
+        let lambda = P2.1.lambda_numerator.__mul(Z_inverse);
 
-    let lhs = (lambda.__add(lambda)).__mul(P.y);
-    let rhs = (P.x.__add(P.x).__add(P.x)).__mul(P.x);
+        let lhs = (lambda.__add(lambda)).__mul(P.y);
+        let rhs = (P.x.__add(P.x).__add(P.x)).__mul(P.x);
 
-    assert(lhs.eq(rhs));
+        assert(lhs.eq(rhs));
 
-    let X2 = P2.1.x3;
-    let Y2 = P2.1.y3;
-    let ZZ = Z_inverse.__mul(Z_inverse);
-    let ZZZ = ZZ.__mul(Z_inverse);
+        let X2 = P2.1.x3;
+        let Y2 = P2.1.y3;
+        let ZZ = Z_inverse.__mul(Z_inverse);
+        let ZZZ = ZZ.__mul(Z_inverse);
 
-    let x2 = X2.__mul(ZZ);
-    let y2 = Y2.__mul(ZZZ);
+        let x2 = X2.__mul(ZZ);
+        let y2 = Y2.__mul(ZZZ);
 
-    // ### test add transcript
-    let P3 = unsafe {
-        P.incomplete_add(P2.0)
-    };
-    let Z_inverse = P3.1.z3.__invmod();
+        // ### test add transcript
+        let P3 = unsafe {
+            P.incomplete_add(P2.0)
+        };
+        let Z_inverse = P3.1.z3.__invmod();
 
-    let lambda = P3.1.lambda_numerator.__mul(Z_inverse);
+        let lambda = P3.1.lambda_numerator.__mul(Z_inverse);
 
-    let x1 = P.x;
-    let y1 = P.y;
+        let x1 = P.x;
+        let y1 = P.y;
 
-    let lhs = lambda.__mul(x2.__sub(x1));
-    let rhs = y2.__sub(y1);
-    assert(lhs.eq(rhs));
+        let lhs = lambda.__mul(x2.__sub(x1));
+        let rhs = y2.__sub(y1);
+
+        assert(lhs.eq(rhs));
+    }
 }
 
 #[test]
 fn test_double_with_hint() {
-    let P: BN254J = CurveJ::one();
+    unsafe {
+        let P: BN254J = CurveJ::one();
 
-    let P2 = unsafe {
-        P.dbl()
-    };
+        let P2 = unsafe {
+            P.dbl()
+        };
 
-    let P_affine: BN254 = BigCurve::one();
+        let P_affine: BN254 = BigCurve::one();
 
-    let Z_inverse = P2.1.z3.__invmod();
+        let Z_inverse = P2.1.z3.__invmod();
 
-    let lambda = P2.1.lambda_numerator.__mul(Z_inverse);
+        let lambda = P2.1.lambda_numerator.__mul(Z_inverse);
 
-    let X3 = P2.1.x3;
-    let Y3 = P2.1.y3;
-    let ZZ = Z_inverse.__mul(Z_inverse);
-    let ZZZ = ZZ.__mul(Z_inverse);
+        let X3 = P2.1.x3;
+        let Y3 = P2.1.y3;
+        let ZZ = Z_inverse.__mul(Z_inverse);
+        let ZZZ = ZZ.__mul(Z_inverse);
 
-    let x3 = X3.__mul(ZZ);
-    let y3 = Y3.__mul(ZZZ);
+        let x3 = X3.__mul(ZZ);
+        let y3 = Y3.__mul(ZZZ);
 
-    let transcript: AffineTranscript<Fq> = AffineTranscript { lambda, x3, y3 };
-    let P2_affine = P_affine.double_with_hint(transcript);
+        let transcript: AffineTranscript<Fq> = AffineTranscript { lambda, x3, y3 };
+        let P2_affine = P_affine.double_with_hint(transcript);
 
-    assert(P2_affine.x.eq(x3));
-    assert(P2_affine.y.eq(y3));
+        assert(P2_affine.x.eq(x3));
+        assert(P2_affine.y.eq(y3));
+    }
 }
 
 #[test]
 fn test_incomplete_add_with_hint() {
-    let P: BN254J = CurveJ::one();
+    unsafe {
+        let P: BN254J = CurveJ::one();
 
-    // Q = 2P
-    let Q_affine: BN254 = BigCurve {
-        x: BigNum { limbs: [0x7816a916871ca8d3c208c16d87cfd3, 0x44e72e131a029b85045b68181585d9, 0x0306] },
-        y: BigNum { limbs: [0xa6a449e3538fc7ff3ebf7a5a18a2c4, 0x738c0e0a7c92e7845f96b2ae9c0a68, 0x15ed] },
-        is_infinity: false
-    };
-    let Q = CurveJ::from(Q_affine);
-    let R = unsafe {
-        P.incomplete_add(Q)
-    };
+        // Q = 2P
+        let Q_affine: BN254 = BigCurve {
+            x: BigNum { limbs: [0x7816a916871ca8d3c208c16d87cfd3, 0x44e72e131a029b85045b68181585d9, 0x0306] },
+            y: BigNum { limbs: [0xa6a449e3538fc7ff3ebf7a5a18a2c4, 0x738c0e0a7c92e7845f96b2ae9c0a68, 0x15ed] },
+            is_infinity: false
+        };
+        let Q = CurveJ::from(Q_affine);
+        let R = unsafe {
+            P.incomplete_add(Q)
+        };
 
-    let P_affine: BN254 = BigCurve::one();
+        let P_affine: BN254 = BigCurve::one();
 
-    let Z_inverse = R.1.z3.__invmod();
+        let Z_inverse = R.1.z3.__invmod();
 
-    let lambda = R.1.lambda_numerator.__mul(Z_inverse);
+        let lambda = R.1.lambda_numerator.__mul(Z_inverse);
 
-    let X3 = R.1.x3;
-    let Y3 = R.1.y3;
-    let ZZ = Z_inverse.__mul(Z_inverse);
-    let ZZZ = ZZ.__mul(Z_inverse);
+        let X3 = R.1.x3;
+        let Y3 = R.1.y3;
+        let ZZ = Z_inverse.__mul(Z_inverse);
+        let ZZZ = ZZ.__mul(Z_inverse);
 
-    let x3 = X3.__mul(ZZ);
-    let y3 = Y3.__mul(ZZZ);
+        let x3 = X3.__mul(ZZ);
+        let y3 = Y3.__mul(ZZZ);
 
-    let transcript: AffineTranscript<Fq> = AffineTranscript { lambda, x3, y3 };
-    let P2_affine = P_affine.incomplete_add_with_hint(Q_affine, transcript);
+        let transcript: AffineTranscript<Fq> = AffineTranscript { lambda, x3, y3 };
+        let P2_affine = P_affine.incomplete_add_with_hint(Q_affine, transcript);
 
-    assert(P2_affine.x.eq(x3));
-    assert(P2_affine.y.eq(y3));
+        assert(P2_affine.x.eq(x3));
+        assert(P2_affine.y.eq(y3));
 
-    let P: BN254J = CurveJ::one();
+        let P: BN254J = CurveJ::one();
 
-    let lhs = unsafe {
-        P.dbl().0.dbl().0
-    };
-    let rhs = unsafe {
-        P.dbl().0.incomplete_add(P).0.incomplete_add(P).0
-    };
-    assert(lhs.eq(rhs));
+        let lhs = unsafe {
+            P.dbl().0.dbl().0
+        };
+        let rhs = unsafe {
+            P.dbl().0.incomplete_add(P).0.incomplete_add(P).0
+        };
+        assert(lhs.eq(rhs));
+    }
 }
 
 #[test]
 fn test_add() {
-    let P: BN254 = BigCurve::one();
+    unsafe {
+        let P: BN254 = BigCurve::one();
 
-    // Q = 2P
-    let Q: BN254 = BigCurve {
-        x: BigNum { limbs: [0x7816a916871ca8d3c208c16d87cfd3, 0x44e72e131a029b85045b68181585d9, 0x0306] },
-        y: BigNum { limbs: [0xa6a449e3538fc7ff3ebf7a5a18a2c4, 0x738c0e0a7c92e7845f96b2ae9c0a68, 0x15ed] },
-        is_infinity: false
-    };
+        // Q = 2P
+        let Q: BN254 = BigCurve {
+            x: BigNum { limbs: [0x7816a916871ca8d3c208c16d87cfd3, 0x44e72e131a029b85045b68181585d9, 0x0306] },
+            y: BigNum { limbs: [0xa6a449e3538fc7ff3ebf7a5a18a2c4, 0x738c0e0a7c92e7845f96b2ae9c0a68, 0x15ed] },
+            is_infinity: false
+        };
 
-    let result = CurveJ::from(P.add(Q));
+        let result = CurveJ::from(P.add(Q));
 
-    let P_j = CurveJ::from(P);
-    let Q_j = CurveJ::from(Q);
-    let expected = unsafe {
-        P_j.add(Q_j).0
-    };
+        let P_j = CurveJ::from(P);
+        let Q_j = CurveJ::from(Q);
+        let expected = unsafe {
+            P_j.add(Q_j).0
+        };
 
-    assert(result.eq(expected));
+        assert(result.eq(expected));
 
-    // doubling
-    let Q: BN254 = BigCurve::one();
+        // doubling
+        let Q: BN254 = BigCurve::one();
 
-    let result = CurveJ::from(P.add(Q));
-    let expected = unsafe {
-        P_j.dbl().0
-    };
-    assert(result.eq(expected));
+        let result = CurveJ::from(P.add(Q));
+        let expected = unsafe {
+            P_j.dbl().0
+        };
+        assert(result.eq(expected));
 
-    // infinity
-    let Q = P.neg();
-    let result = CurveJ::from(P.add(Q));
-    let expected = unsafe {
-        CurveJ::point_at_infinity()
-    };
-    assert(result.eq(expected));
+        // infinity
+        let Q = P.neg();
+        let result = CurveJ::from(P.add(Q));
+        let expected = unsafe {
+            CurveJ::point_at_infinity()
+        };
+        assert(result.eq(expected));
 
-    // lhs infinity
-    let P: BN254 = BigCurve::point_at_infinity();
-    let result = CurveJ::from(P.add(Q));
-    let expected = CurveJ::from(Q);
-    assert(result.eq(expected));
+        // lhs infinity
+        let P: BN254 = BigCurve::point_at_infinity();
+        let result = CurveJ::from(P.add(Q));
+        let expected = CurveJ::from(Q);
+        assert(result.eq(expected));
 
-    // rhs infinity
-    let result = CurveJ::from(Q.add(P));
-    assert(result.eq(expected));
+        // rhs infinity
+        let result = CurveJ::from(Q.add(P));
+        assert(result.eq(expected));
 
-    // both infinity
-    let Q: BN254 = BigCurve::point_at_infinity();
-    let result = CurveJ::from(Q.add(P));
-    let expected = unsafe {
-        CurveJ::point_at_infinity()
-    };
-    assert(result.eq(expected));
+        // both infinity
+        let Q: BN254 = BigCurve::point_at_infinity();
+        let result = CurveJ::from(Q.add(P));
+        let expected = unsafe {
+            CurveJ::point_at_infinity()
+        };
+        assert(result.eq(expected));
+    }
 }
 
 #[test]
 fn test_sub() {
-    let P: BN254 = BigCurve::one();
+    unsafe {
+        let P: BN254 = BigCurve::one();
 
-    // Q = 2P
-    let Q: BN254 = BigCurve {
-        x: BigNum { limbs: [0x7816a916871ca8d3c208c16d87cfd3, 0x44e72e131a029b85045b68181585d9, 0x0306] },
-        y: BigNum { limbs: [0xa6a449e3538fc7ff3ebf7a5a18a2c4, 0x738c0e0a7c92e7845f96b2ae9c0a68, 0x15ed] },
-        is_infinity: false
-    };
+        // Q = 2P
+        let Q: BN254 = BigCurve {
+            x: BigNum { limbs: [0x7816a916871ca8d3c208c16d87cfd3, 0x44e72e131a029b85045b68181585d9, 0x0306] },
+            y: BigNum { limbs: [0xa6a449e3538fc7ff3ebf7a5a18a2c4, 0x738c0e0a7c92e7845f96b2ae9c0a68, 0x15ed] },
+            is_infinity: false
+        };
 
-    let result = CurveJ::from(P.sub(Q));
+        let result = CurveJ::from(P.sub(Q));
 
-    let P_j = CurveJ::from(P);
-    let Q_j = CurveJ::from(Q);
-    let expected = unsafe {
-        P_j.sub(Q_j).0
-    };
+        let P_j = CurveJ::from(P);
+        let Q_j = CurveJ::from(Q);
+        let expected = unsafe {
+            P_j.sub(Q_j).0
+        };
 
-    assert(result.eq(expected));
+        assert(result.eq(expected));
 
-    // doubling
-    let Q: BN254 = BigCurve::one();
+        // doubling
+        let Q: BN254 = BigCurve::one();
 
-    let result = CurveJ::from(P.sub(Q.neg()));
-    let expected = unsafe {
-        P_j.dbl().0
-    };
-    assert(result.eq(expected));
+        let result = CurveJ::from(P.sub(Q.neg()));
+        let expected = unsafe {
+            P_j.dbl().0
+        };
+        assert(result.eq(expected));
 
-    // infinity
-    let result = CurveJ::from(P.sub(Q));
-    let expected = unsafe {
-        CurveJ::point_at_infinity()
-    };
-    assert(result.eq(expected));
+        // infinity
+        let result = CurveJ::from(P.sub(Q));
+        let expected = unsafe {
+            CurveJ::point_at_infinity()
+        };
+        assert(result.eq(expected));
 
-    // lhs infinity
-    let P: BN254 = BigCurve::point_at_infinity();
-    let result = CurveJ::from(P.sub(Q));
-    let expected = CurveJ::from(Q.neg());
-    assert(result.eq(expected));
+        // lhs infinity
+        let P: BN254 = BigCurve::point_at_infinity();
+        let result = CurveJ::from(P.sub(Q));
+        let expected = CurveJ::from(Q.neg());
+        assert(result.eq(expected));
 
-    // rhs infinity
-    let result = CurveJ::from(Q.sub(P));
-    let expected = expected.neg();
-    assert(result.eq(expected));
+        // rhs infinity
+        let result = CurveJ::from(Q.sub(P));
+        let expected = expected.neg();
+        assert(result.eq(expected));
 
-    // both infinity
-    let Q: BN254 = BigCurve::point_at_infinity();
-    let result = CurveJ::from(Q.sub(P));
-    let expected = unsafe {
-        CurveJ::point_at_infinity()
-    };
-    assert(result.eq(expected));
+        // both infinity
+        let Q: BN254 = BigCurve::point_at_infinity();
+        let result = CurveJ::from(Q.sub(P));
+        let expected = unsafe {
+            CurveJ::point_at_infinity()
+        };
+        assert(result.eq(expected));
+    }
 }
 
 #[test]
 fn test_make_table() {
-    let P: BN254J = CurveJ::one();
+    unsafe {
+        let P: BN254J = CurveJ::one();
 
-    let mut transcript: [JTranscript<Fq>] = &[];
-    let T: curve_jac::PointTable<Fq> = unsafe {
-        curve_jac::PointTable::new(P)
-    };
-    for i in 0..8 {
-        transcript = transcript.push_back(T.transcript[i]);
-    }
+        let mut transcript: [JTranscript<Fq>] = &[];
+        let T: curve_jac::PointTable<Fq> = unsafe {
+            curve_jac::PointTable::new(P)
+        };
+        for i in 0..8 {
+            transcript = transcript.push_back(T.transcript[i]);
+        }
 
-    let mut inverses: [Fq; 8] = [BigNum::new(); 8];
+        let mut inverses: [Fq; 8] = [BigNum::new(); 8];
 
-    for i in 0..8 {
-        inverses[i] = transcript[i].z3;
-    }
+        for i in 0..8 {
+            inverses[i] = transcript[i].z3;
+        }
 
-    inverses = BigNum::__batch_invert(inverses);
+        inverses = BigNum::__batch_invert(inverses);
 
-    let mut affine_transcript: [AffineTranscript<Fq>; 8] = [AffineTranscript::new(); 8];
-    for i in 0..8 {
-        let z_inv = inverses[i];
+        let mut affine_transcript: [AffineTranscript<Fq>; 8] = [AffineTranscript::new(); 8];
+        for i in 0..8 {
+            let z_inv = inverses[i];
 
-        let lambda = transcript[i].lambda_numerator.__mul(z_inv);
-        let zz = z_inv.__mul(z_inv);
-        let zzz = zz.__mul(z_inv);
-        let x3 = transcript[i].x3.__mul(zz);
-        let y3 = transcript[i].y3.__mul(zzz);
-        affine_transcript[i] = AffineTranscript{ lambda, x3, y3 };
-    }
+            let lambda = transcript[i].lambda_numerator.__mul(z_inv);
+            let zz = z_inv.__mul(z_inv);
+            let zzz = zz.__mul(z_inv);
+            let x3 = transcript[i].x3.__mul(zz);
+            let y3 = transcript[i].y3.__mul(zzz);
+            affine_transcript[i] = AffineTranscript{ lambda, x3, y3 };
+        }
 
-    let P_affine: BN254 = BigCurve::one();
+        let P_affine: BN254 = BigCurve::one();
 
-    let affine_point_table: PointTable<Fq> = PointTable::new_with_hint(P_affine, affine_transcript);
+        let affine_point_table: PointTable<Fq> = PointTable::new_with_hint(P_affine, affine_transcript);
 
-    for i in 0..8 {
-        let point: BN254 = affine_point_table.get(i);
-        point.validate_on_curve();
+        for i in 0..8 {
+            let point: BN254 = affine_point_table.get(i);
+            point.validate_on_curve();
+        }
     }
 }
 
-// #[test]
-// fn test_ScalarField_BigNum_conversion() {
-//     assert(BNParams::modulus_bits() == 254);
-//     let expected: Fq = BigNum::__derive_from_seed([1, 2, 3, 4]);
-//     let scalar: ScalarField<64> = ScalarField::from_bignum(expected);
-//     let result: Fq = scalar.into_bignum();
-//     assert(result.limbs == expected.limbs);
-// }
+use dep::bignum::fields::bn254Fq::BNParams;
+
+use crate::curves::vesta::{Vesta, VestaFr, VestaScalar};
+use crate::curves::pallas::{Pallas, PallasFr, PallasScalar};
+use crate::curves::bls12_377::{BLS12_377, BLS12_377Fr, BLS12_377Scalar};
+use crate::curves::bls12_381::{BLS12_381, BLS12_381Fr, BLS12_381Scalar};
+use crate::curves::secp256k1::{Secp256k1, Secp256k1Fr, Secp256k1Scalar};
+use crate::curves::secp256r1::{Secp256r1, Secp256r1Fr, Secp256r1Scalar};
+use crate::curves::secp384r1::{Secp384r1, Secp384r1Fr, Secp384r1Scalar};
+use crate::curves::mnt4_753::{MNT4_753, MNT4_753Fr, MNT4_753Scalar};
+use crate::curves::mnt6_753::{MNT6_753, MNT6_753Fr, MNT6_753Scalar};
+
+//comptime fn 
+comptime fn make_test(f: StructDefinition, Curve: Quoted, Fr: Quoted, ScalarType: Quoted) -> Quoted {
+    let k = f.name();
+    let mut offset_generator_test: Quoted = quote{};
+    // hacky workaround because we don't have a defined BN254Fr BigNum instance (assumption is the circuit field is BN254 :o)
+    if (!Curve.eq(quote{BN254})) {
+        offset_generator_test = quote{#[test]
+fn test_offset_generators() {
+    let one: $Curve = BigCurve::one();
+    let negone: $Fr = BigNum::one().neg();
+    let scalar: $ScalarType  = ScalarField::from_bignum(negone);
+    let final = one.mul(scalar);
+    assert(final.eq(one.neg()));
+}};
+    } else {
+        offset_generator_test = quote{#[test]
+fn test_offset_generators() {
+    let one: $Curve = BigCurve::one();
+    let scalar: $ScalarType  = ScalarField::from(-1);
+    let final = one.mul(scalar);
+    assert(final.eq(one.neg()));
+}};
+    }
+    quote{
+impl $k {
+$offset_generator_test
+
+#[test]
+    fn test_num_scalar_slices_in_scalar_field() {
+        let x: $Fr = BigNum::new();
+        let max_wnaf_bits: u32 = x.modulus_bits() + 1;
+
+        let scalar_slices = (max_wnaf_bits / 4) + (max_wnaf_bits % 4 != 0) as u32;
+        let scalar: $ScalarType = ScalarField::zero();
+        let expected = scalar.len();
+        assert(scalar_slices == expected);
+
+    }
+
+
+#[test]
+fn test_hash_to_curve() {
+
+    let r: $Curve = BigCurve::hash_to_curve("hello world".as_bytes());
+    r.validate_on_curve();
+}
+
+
+
+#[test]
+fn test_msm() {
+
+    // (p-4)[X] + (p-5)[-X] = [X]
+    let mut four: $Fr = BigNum::new();
+    four.limbs[0] = 4;
+    let p_minus_4_fr: $Fr = BigNum::modulus() - four;
+    let p_minus_4: $ScalarType = ScalarField::from_bignum(p_minus_4_fr);
+    let p_minus_5_fr = p_minus_4_fr - BigNum::one();
+    let p_minus_5: $ScalarType = ScalarField::from_bignum(p_minus_5_fr);
+
+    let mut scalars: [$ScalarType; 2] = [p_minus_4, p_minus_5];
+
+    let A: $Curve = BigCurve::one();
+    let B = A.neg();
+    let mut points: [$Curve; 2] = [A, B];
+    // -4.[1] -5.[-1] + [1] = [0]
+    let result: $Curve = BigCurve::evaluate_linear_expression(points, scalars, [BigCurve::one().neg()]);
+    assert(result.is_infinity);
+}
+}
+}
+}
+
+#[make_test(quote{BN254}, quote{BigNum<3, BNParams>}, quote{BN254Scalar})]
+pub struct BN254GenTests{}
+#[make_test(quote{Vesta}, quote{VestaFr}, quote{VestaScalar})]
+pub struct VestaGenTests{}
+#[make_test(quote{Pallas}, quote{PallasFr}, quote{PallasScalar})]
+pub struct PallasGenTests{}
+#[make_test(quote{BLS12_377}, quote{BLS12_377Fr}, quote{BLS12_377Scalar})]
+pub struct BLS377GenTests{}
+#[make_test(quote{BLS12_381}, quote{BLS12_381Fr}, quote{BLS12_381Scalar})]
+pub struct BLS381GenTests{}
+#[make_test(quote{Secp256k1}, quote{Secp256k1Fr}, quote{Secp256k1Scalar})]
+pub struct Secp256k1GenTests{}
+#[make_test(quote{Secp256r1}, quote{Secp256r1Fr}, quote{Secp256r1Scalar})]
+pub struct Secp256r1GenTests{}
+#[make_test(quote{Secp384r1}, quote{Secp384r1Fr}, quote{Secp384r1Scalar})]
+pub struct Secp384r1GenTests{}
+#[make_test(quote{MNT4_753}, quote{MNT4_753Fr}, quote{MNT4_753Scalar})]
+pub struct MNT4GenTests{}
+#[make_test(quote{MNT6_753}, quote{MNT6_753Fr}, quote{MNT6_753Scalar})]
+pub struct MNT6GenTests{}

--- a/src/curve_jac.nr
+++ b/src/curve_jac.nr
@@ -22,7 +22,7 @@ use crate::BigCurve;
  *              i.e. we compute 1 modular inverse instead of ~256 or 320 depending on the elliptic curve.
  *              Yes, this is an extremely complex solution to a simple problem. Such is life. Inverses are expensive to generate witnesses for.
  **/
-struct CurveJ<BigNum, CurveParams> {
+pub struct CurveJ<BigNum, CurveParams> {
     x: BigNum,
     y: BigNum,
     z: BigNum,
@@ -34,14 +34,14 @@ struct CurveJ<BigNum, CurveParams> {
  * x3, y3, z3 = the output of the group operation
  * lambda_numerator = numerator of the `lambda` term (the denominator is assumed to be z3)
  **/
-struct JTranscript<BigNum> {
+pub struct JTranscript<BigNum> {
     lambda_numerator: BigNum,
     x3: BigNum,
     y3: BigNum,
     z3: BigNum
 }
 
-impl<BigNum> JTranscript<BigNum> where BigNum: BigNumTrait {
+impl<BigNum> JTranscript<BigNum> where BigNum: BigNumTrait + std::ops::Add + std::ops::Mul + std::cmp::Eq {
     unconstrained fn new() -> Self {
         JTranscript { lambda_numerator: BigNum::new(), x3: BigNum::new(), y3: BigNum::new(), z3: BigNum::new() }
     }
@@ -55,7 +55,7 @@ impl<BigNum> JTranscript<BigNum> where BigNum: BigNumTrait {
  * For doubling, lambda = (3 * x1 * x1) / (2 * y1)
  * If we have an array of JTranscript objects, we can turn them into AffineTranscript objects with only 1 modular inverse
  **/
-struct AffineTranscript<BigNum> {
+pub struct AffineTranscript<BigNum> {
     lambda: BigNum,
     x3: BigNum,
     y3: BigNum
@@ -64,7 +64,7 @@ struct AffineTranscript<BigNum> {
 /**
  * @brief construct a sequence of AffineTranscript objects from a sequence of Jacobian transcript objects
  **/
-impl<BigNum> AffineTranscript<BigNum> where BigNum: BigNumTrait {
+impl<BigNum> AffineTranscript<BigNum> where BigNum: BigNumTrait + std::ops::Add + std::ops::Mul + std::cmp::Eq {
     fn new() -> Self {
         AffineTranscript { lambda: BigNum::new(), x3: BigNum::new(), y3: BigNum::new() }
     }
@@ -117,14 +117,14 @@ impl<BigNum> AffineTranscript<BigNum> where BigNum: BigNumTrait {
  * For each iteration `i` we double the accumulator 4 times and then add `T[slice[i]]` into the accumulator.
  * For small multiscalar multiplications (i.e. <512 points) this produces the minimal number of addition operations.
  **/
-struct PointTable<BigNum> {
+pub struct PointTable<BigNum> {
     x: [BigNum; 16],
     y: [BigNum; 16],
     z: [BigNum; 16],
     transcript: [JTranscript<BigNum>; 8]
 }
 
-impl<BigNum> PointTable<BigNum> where BigNum: BigNumTrait {
+impl<BigNum> PointTable<BigNum> where BigNum: BigNumTrait + std::ops::Add + std::ops::Mul + std::cmp::Eq {
     fn empty() -> Self {
         PointTable {
             x: [BigNum::new(); 16],
@@ -152,6 +152,7 @@ impl<BigNum> PointTable<BigNum> where BigNum: BigNumTrait {
         };
         let op = P.dbl();
         let D2 = op.0;
+
         result.transcript[0] = op.1;
         result.x[7] = P.x;
         result.y[7] = P.y.__neg();
@@ -186,7 +187,7 @@ impl<BigNum> PointTable<BigNum> where BigNum: BigNumTrait {
 /**
  * @brief construct from BigCurve
  **/
-impl<BigNum, CurveParams> std::convert::From<BigCurve<BigNum, CurveParams>> for CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait, CurveParams: CurveParamsTrait<BigNum> {
+impl<BigNum, CurveParams> std::convert::From<BigCurve<BigNum, CurveParams>> for CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait + std::ops::Add + std::ops::Mul + std::cmp::Eq, CurveParams: CurveParamsTrait<BigNum> {
     fn from(affine_point: BigCurve<BigNum, CurveParams>) -> Self {
         CurveJ { x: affine_point.x, y: affine_point.y, z: BigNum::one(), is_infinity: affine_point.is_infinity }
     }
@@ -196,42 +197,44 @@ impl<BigNum, CurveParams> std::convert::From<BigCurve<BigNum, CurveParams>> for 
  * @brief are two Jacobian points equal?
  * @description only really used in tests for now.
  **/
-impl<BigNum, CurveParams> std::cmp::Eq for CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait, CurveParams: CurveParamsTrait<BigNum> {
+impl<BigNum, CurveParams> std::cmp::Eq for CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait + std::ops::Add + std::ops::Mul + std::cmp::Eq, CurveParams: CurveParamsTrait<BigNum> {
     fn eq(self, other: Self) -> bool {
         // if x == y then (X1 / Z1 * Z1 = X2 / Z2 * Z2)
         //            and (Y1 / Z1 * Z1 * Z1 = Y2 / Z2 * Z2 * Z2)
+        let mut points_equal = false;
+        unsafe {
+            // we can check this by validating that:
+            // X1 * Z2 * Z2 == X2 * Z1 * Z1
+            // Y1 * Z2 * Z2 * Z2 == Y2 * Z1 * Z1 * Z1
+            let z1 = self.z;
+            let z2 = other.z;
+            let z1z1 = z1.__mul(z1);
+            let z1z1z1 = z1z1.__mul(z1);
+            let z2z2 = z2.__mul(z2);
+            let z2z2z2 = z2z2.__mul(z2);
 
-        // we can check this by validating that:
-        // X1 * Z2 * Z2 == X2 * Z1 * Z1
-        // Y1 * Z2 * Z2 * Z2 == Y2 * Z1 * Z1 * Z1
-        let z1 = self.z;
-        let z2 = other.z;
-        let z1z1 = z1.__mul(z1);
-        let z1z1z1 = z1z1.__mul(z1);
-        let z2z2 = z2.__mul(z2);
-        let z2z2z2 = z2z2.__mul(z2);
+            let x_lhs = self.x.__mul(z2z2);
+            let x_rhs = other.x.__mul(z1z1);
+            let y_lhs = self.y.__mul(z2z2z2);
+            let y_rhs = other.y.__mul(z1z1z1);
+            let lhs_infinity = self.is_infinity;
+            let rhs_infinity = other.is_infinity;
+            let both_not_infinity = !(lhs_infinity & rhs_infinity);
+            let both_infinity = !both_not_infinity;
 
-        let x_lhs = self.x.__mul(z2z2);
-        let x_rhs = other.x.__mul(z1z1);
-        let y_lhs = self.y.__mul(z2z2z2);
-        let y_rhs = other.y.__mul(z1z1z1);
-        let lhs_infinity = self.is_infinity;
-        let rhs_infinity = other.is_infinity;
-        let both_not_infinity = !(lhs_infinity & rhs_infinity);
-        let both_infinity = !both_not_infinity;
-
-        let mut points_equal = (x_lhs.eq(x_rhs) & y_lhs.eq(y_rhs)) & both_not_infinity;
-        points_equal = points_equal | both_infinity;
+            points_equal = (x_lhs.eq(x_rhs) & y_lhs.eq(y_rhs)) & both_not_infinity;
+            points_equal = points_equal | both_infinity;
+        }
         points_equal
     }
 }
 
-impl<BigNum, CurveParams> CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait, CurveParams: CurveParamsTrait<BigNum> {
+impl<BigNum, CurveParams> CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait + std::ops::Add + std::ops::Mul + std::cmp::Eq, CurveParams: CurveParamsTrait<BigNum> {
     /**
      * @brief negate a point
      **/
     fn neg(self) -> Self {
-        CurveJ { x: self.x, y: self.y.__neg(), z: self.z, is_infinity: self.is_infinity }
+        CurveJ { x: self.x, y: self.y.neg(), z: self.z, is_infinity: self.is_infinity }
     }
 
     unconstrained fn new() -> Self {
@@ -247,7 +250,6 @@ impl<BigNum, CurveParams> CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait,
     }
 
     unconstrained fn add(self, p2: Self) -> (Self, JTranscript<BigNum>) {
-        // TODO: once we have linear expressions as unconstrained fns, replace this with something that has no addmods, submods
         let X1 = self.x;
         let X2 = p2.x;
         let Y1 = self.y;
@@ -333,7 +335,6 @@ impl<BigNum, CurveParams> CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait,
      * which is NOT the same as minimizing the number of multiplications.
      **/
     unconstrained fn incomplete_add(self, p2: Self) -> (Self, JTranscript<BigNum>) {
-        // TODO: once we have linear expressions as unconstrained fns, replace this with something that has no addmods, submods
         let X1 = self.x;
         let X2 = p2.x;
         let Y1 = self.y;
@@ -351,7 +352,6 @@ impl<BigNum, CurveParams> CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait,
         let R = S2.__sub(S1);
 
         let (_, PP): (BigNum, BigNum ) = BigNum::__compute_quadratic_expression([[U2, U1]], [[false, true]], [[U2, U1]], [[false, true]], [], []);
-
         let (_, X3): (BigNum, BigNum ) = BigNum::__compute_quadratic_expression(
             [[BigNum::new(), PP], [R, BigNum::new()]],
             [[false, true], [false, false]],
@@ -386,12 +386,16 @@ impl<BigNum, CurveParams> CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait,
             [],
             []
         );
-
         (
             CurveJ { x: X3, y: Y3, z: Z3, is_infinity: false }, JTranscript { lambda_numerator: R, x3: X3, y3: Y3, z3: Z3 }
         )
     }
 
+    unconstrained fn conditional_incomplete_add(self, p2: Self, predicate: bool) -> (Self, JTranscript<BigNum>) {
+        let mut operand_output = self.incomplete_add(p2);
+        let result = CurveJ::conditional_select(operand_output.0, self, predicate);
+        (result, operand_output.1)
+    }
     /**
      * @brief Double a point
      * @note This method minimizes the number of calls to `compute_quadratic_expression`,
@@ -401,9 +405,8 @@ impl<BigNum, CurveParams> CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait,
         let X1 = self.x;
         let Y1 = self.y;
         let Z1 = self.z;
-
         let (_, YY_mul_2): (BigNum, BigNum ) = BigNum::__compute_quadratic_expression([[Y1]], [[false]], [[Y1, Y1]], [[false, false]], [], []);
-        let (_, XX_mul_3): (BigNum, BigNum ) = BigNum::__compute_quadratic_expression(
+        let mut (_, XX_mul_3): (BigNum, BigNum ) = BigNum::__compute_quadratic_expression(
             [[X1]],
             [[false]],
             [[X1, X1, X1]],
@@ -411,6 +414,12 @@ impl<BigNum, CurveParams> CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait,
             [],
             []
         );
+
+        if (CurveParams::a().get_limb(0) != 0) {
+            let ZZ = Z1.__mul(Z1);
+            let AZZZZ = ZZ.__mul(ZZ).__mul(CurveParams::a());
+            XX_mul_3 = XX_mul_3.__add(AZZZZ);
+        }
         let (_, D): (BigNum, BigNum ) = BigNum::__compute_quadratic_expression([[X1, X1]], [[false, false]], [[YY_mul_2]], [[false]], [], []);
         let mut (_, X3): (BigNum, BigNum ) = BigNum::__compute_quadratic_expression(
             [[XX_mul_3]],
@@ -428,12 +437,7 @@ impl<BigNum, CurveParams> CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait,
             [],
             []
         );
-        // TODO: tidy this up and make more efficient?!
-        if (CurveParams::a().get_limb(0) != 0) {
-            let ZZ = Z1.mul(Z1);
-            let AZZZZ = ZZ.mul(ZZ).mul(CurveParams::a());
-            X3 = X3.add(AZZZZ);
-        }
+        // 3XX * (D - X3) - 8YYYY
         let (_, Z3): (BigNum, BigNum ) = BigNum::__compute_quadratic_expression([[Y1]], [[false]], [[Z1, Z1]], [[false, false]], [], []);
         (
             CurveJ { x: X3, y: Y3, z: Z3, is_infinity: false }, JTranscript { lambda_numerator: XX_mul_3, x3: X3, y3: Y3, z3: Z3 }
@@ -495,15 +499,10 @@ impl<BigNum, CurveParams> CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait,
             accumulator = op.0;
         }
 
-        if scalar.skew {
-            let op = accumulator.incomplete_add(input.neg());
-            transcript[ptr] = op.1;
-            ptr += 1;
-            accumulator = op.0;
-        } else {
-            transcript[ptr] = JTranscript::new();
-            ptr += 1;
-        }
+        let op = accumulator.conditional_incomplete_add(input.neg(), scalar.skew);
+        transcript[ptr] = op.1;
+        accumulator = op.0;
+        ptr += 1;
 
         let op = accumulator.sub(CurveJ::offset_generator_final());
         transcript[ptr] = op.1;
@@ -517,11 +516,11 @@ impl<BigNum, CurveParams> CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait,
     /**
      * @brief Perform an ecc scalar multiplication and output the generated AffineTranscript
      **/
-    unconstrained fn msm_partial<let Size: u32, let NScalarSlices: u32>(
-        mut points: [Self; Size],
-        mut scalars: [ScalarField<NScalarSlices>; Size]
-    ) -> (Self, [JTranscript<BigNum>; NScalarSlices * Size + NScalarSlices * 4 + Size * 9 - 3]) {
-        let mut transcript: [JTranscript<BigNum>; NScalarSlices * Size + NScalarSlices * 4 + Size * 9 - 3] = [JTranscript::new(); NScalarSlices * Size + NScalarSlices * 4 + Size * 9 - 3];
+    unconstrained fn msm_partial<let Size: u32, let NScalarSlices: u32, let TranscriptEntries: u32>(
+        points: [Self; Size],
+        scalars: [ScalarField<NScalarSlices>; Size]
+    ) -> (Self, [JTranscript<BigNum>; TranscriptEntries])/*(Self, [JTranscript<BigNum>; NScalarSlices * Size + NScalarSlices * 4 + Size * 9 - 3]) */ {
+        let mut transcript: [JTranscript<BigNum>; TranscriptEntries] = [JTranscript::new(); TranscriptEntries];
         let mut tables: [PointTable<BigNum>; Size] = [PointTable::empty(); Size];
 
         let mut _inputs: [Self; Size] = [CurveJ::new(); Size];
@@ -530,8 +529,8 @@ impl<BigNum, CurveParams> CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait,
             _inputs[i] = CurveJ::conditional_select(CurveJ::one(), points[i], points[i].is_infinity);
             _scalars[i] = ScalarField::conditional_select(ScalarField::zero(), scalars[i], points[i].is_infinity);
         }
-        points = _inputs;
-        scalars = _scalars;
+        let points = _inputs;
+        let scalars = _scalars;
         let mut ptr: u32 = 0;
         for i in 0..Size {
             tables[i] = PointTable::new(points[i]);
@@ -569,15 +568,10 @@ impl<BigNum, CurveParams> CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait,
         }
 
         for i in 0..Size {
-            if scalars[i].skew {
-                let op = accumulator.incomplete_add(points[i].neg());
-                transcript[ptr] = op.1;
-                ptr += 1;
-                accumulator = op.0;
-            } else {
-                transcript[ptr] = JTranscript::new();
-                ptr += 1;
-            }
+            let op = accumulator.conditional_incomplete_add(points[i].neg(), scalars[i].skew);
+            transcript[ptr] = op.1;
+            accumulator = op.0;
+            ptr += 1;
         }
 
         (accumulator, transcript)
@@ -600,10 +594,10 @@ impl<BigNum, CurveParams> CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait,
     }
 
     unconstrained fn compute_linear_expression_transcript<let NScalarSlices: u32, let NMuls: u32, let NAdds: u32>(
-        mul_points: [BigCurve<BigNum, CurveParams>; NMuls],
-        mul_scalars: [ScalarField<NScalarSlices>; NMuls],
-        add_points: [BigCurve<BigNum, CurveParams>; NAdds]
-    ) -> AffineLinearExpressionTranscript<BigNum, NScalarSlices, NMuls, NAdds> {
+        mut mul_points: [BigCurve<BigNum, CurveParams>; NMuls],
+        mut scalars: [ScalarField<NScalarSlices>; NMuls],
+        mut add_points: [BigCurve<BigNum, CurveParams>; NAdds]
+    ) -> (Self, [AffineTranscript<BigNum>; NScalarSlices * NMuls + NScalarSlices * 4 + NMuls * 9 + NAdds - 3]) {
         let mut mul_j: [CurveJ<BigNum, CurveParams>; NMuls] = [CurveJ::new(); NMuls];
         let mut add_j: [CurveJ<BigNum, CurveParams>; NAdds] = [CurveJ::new(); NAdds];
         for i in 0..NMuls {
@@ -613,183 +607,20 @@ impl<BigNum, CurveParams> CurveJ<BigNum, CurveParams> where BigNum: BigNumTrait,
             add_j[i] = CurveJ::from(add_points[i]);
         }
 
-        let mut jacobian_transcript: LinearExpressionTranscript<BigNum,NScalarSlices,NMuls,NAdds> = LinearExpressionTranscript {
-            table_transcript: [[JTranscript::new(); 8]; NMuls],
-            msm_double_transcript: [[JTranscript::new(); 4]; NScalarSlices],
-            msm_add_transcript: [[JTranscript::new(); NMuls]; NScalarSlices],
-            skew_transcript: [JTranscript::new(); NMuls],
-            add_transcript: [JTranscript::new(); NAdds],
-            offset_generator_transcript: JTranscript::new()
-        };
-
-        // #####
-        let mut tables: [PointTable<BigNum>; NMuls] = [PointTable::empty(); NMuls];
-
-        let mut _inputs: [Self; NMuls] = [CurveJ::new(); NMuls];
-        let mut  _scalars: [ScalarField<NScalarSlices>; NMuls] = [ScalarField::new(); NMuls];
-        for i in 0..NMuls {
-            _inputs[i] = CurveJ::conditional_select(CurveJ::one(), mul_j[i], mul_j[i].is_infinity);
-            _scalars[i] = ScalarField::conditional_select(ScalarField::zero(), mul_scalars[i], mul_j[i].is_infinity);
-        }
-        let points = _inputs;
-        let scalars = _scalars;
-
-        for i in 0..NMuls {
-            tables[i] = PointTable::new(points[i]);
-            for j in 0..8 {
-                jacobian_transcript.table_transcript[i][j] = tables[i].transcript[j];
-            }
-        }
-
-        let mut accumulator: Self = CurveJ::offset_generator();
-        let op = accumulator.incomplete_add(tables[0].get(scalars[0].base4_slices[0]));
-        jacobian_transcript.msm_add_transcript[0][0] = op.1;
-        accumulator = op.0;
-
-        for i in 1..NMuls {
-            let op = accumulator.incomplete_add(tables[i].get(scalars[i].base4_slices[0]));
-            jacobian_transcript.msm_add_transcript[0][i] = op.1;
-            accumulator = op.0;
-        }
-        for i in 1..NScalarSlices {
-            for j in 0..4 {
-                let op = accumulator.dbl();
-                accumulator = op.0;
-                jacobian_transcript.msm_double_transcript[i-1][j] = op.1;
-            }
-            for j in 0..NMuls {
-                let op = accumulator.incomplete_add(tables[j].get(scalars[j].base4_slices[i]));
-                jacobian_transcript.msm_add_transcript[i][j] = op.1;
-                accumulator = op.0;
-            }
-        }
-
-        for i in 0..NMuls {
-            let op = accumulator.incomplete_add(points[i].neg());
-            if scalars[i].skew {
-                jacobian_transcript.skew_transcript[i] = op.1;
-                accumulator = op.0;
-            } else {
-                jacobian_transcript.skew_transcript[i] = op.1;
-            }
-        }
-
+        let mut (accumulator, transcript): (Self, [JTranscript<BigNum>; NScalarSlices * NMuls + NScalarSlices * 4 + NMuls * 9 + NAdds - 3]) = CurveJ::msm_partial(mul_j, scalars);
+        let mut transcript_ptr: u32 = NScalarSlices * NMuls + NScalarSlices * 4 + NMuls * 9 - 4;
         for i in 0..NAdds {
-            let op = accumulator.incomplete_add(add_j[i]);
-            jacobian_transcript.add_transcript[i] = op.1;
+            let op = accumulator.conditional_incomplete_add(add_j[i], !add_j[i].is_infinity);
+            transcript[transcript_ptr] = op.1;
             accumulator = op.0;
+            transcript_ptr += 1;
         }
 
         let op = accumulator.sub(CurveJ::offset_generator_final());
-        jacobian_transcript.offset_generator_transcript = op.1;
+        transcript[transcript_ptr] = op.1;
         accumulator = op.0;
+        let affine_transcript: [AffineTranscript<BigNum>; NScalarSlices * NMuls + NScalarSlices * 4 + NMuls * 9 + NAdds - 3] = AffineTranscript::from_jacobian_transcript(transcript);
 
-        let affine_transcript: AffineLinearExpressionTranscript<BigNum, NScalarSlices, NMuls, NAdds> = AffineLinearExpressionTranscript::from_jtranscript(jacobian_transcript);
-        affine_transcript
-    }
-}
-
-struct LinearExpressionTranscript<BigNum, let NScalarSlices: u32, let NMuls: u32, let NAdds: u32>{
-    table_transcript: [[JTranscript<BigNum>; 8]; NMuls],
-    msm_double_transcript: [[JTranscript<BigNum>; 4]; NScalarSlices],
-    msm_add_transcript: [[JTranscript<BigNum>; NMuls]; NScalarSlices],
-    skew_transcript: [JTranscript<BigNum>; NMuls],
-    add_transcript: [JTranscript<BigNum>; NAdds],
-    offset_generator_transcript: JTranscript<BigNum>
-}
-
-struct AffineLinearExpressionTranscript<BigNum, let NScalarSlices: u32, let NMuls: u32, let NAdds: u32>{
-    table_transcript: [[AffineTranscript<BigNum>; 8]; NMuls],
-    msm_double_transcript: [[AffineTranscript<BigNum>; 4]; NScalarSlices - 1],
-    msm_add_transcript: [[AffineTranscript<BigNum>; NMuls]; NScalarSlices],
-    skew_transcript: [AffineTranscript<BigNum>; NMuls],
-    add_transcript: [AffineTranscript<BigNum>; NAdds],
-    offset_generator_transcript: AffineTranscript<BigNum>
-}
-
-impl<BigNum, let NScalarSlices: u32, let NMuls: u32, let NAdds: u32>  AffineLinearExpressionTranscript<BigNum,NScalarSlices,NMuls,NAdds> where BigNum: BigNumTrait {
-
-    unconstrained fn from_jtranscript(jtranscript: LinearExpressionTranscript<BigNum,  NScalarSlices,  NMuls,  NAdds>) -> Self {
-        let mut inverses: [BigNum; NScalarSlices * NMuls + NScalarSlices * 4 + NMuls * 9 - 3] = [BigNum::new(); NScalarSlices * NMuls + NScalarSlices * 4 + NMuls * 9 - 3];
-
-        let mut ptr: u32 = 0;
-        for i in 0..NMuls {
-            for j in 0..8 {
-                inverses[ptr] = jtranscript.table_transcript[i][j].z3;
-                ptr += 1;
-            }
-        }
-        for i in 0..NMuls {
-            inverses[ptr] = jtranscript.msm_add_transcript[0][i].z3;
-            ptr += 1;
-        }
-        for i in 1..NScalarSlices {
-            for j in 0..4 {
-                inverses[ptr] = jtranscript.msm_double_transcript[i-1][j].z3;
-                ptr += 1;
-            }
-
-            for j in 0..NMuls {
-                inverses[ptr] = jtranscript.msm_add_transcript[i][j].z3;
-                ptr += 1;
-            }
-        }
-
-        for i in 0..NMuls {
-            inverses[ptr] = jtranscript.skew_transcript[i].z3;
-            ptr += 1;
-        }
-        for i in 0..NAdds {
-            inverses[ptr] = jtranscript.add_transcript[i].z3;
-            ptr += 1;
-        }
-        inverses[ptr] = jtranscript.offset_generator_transcript.z3;
-        ptr += 1;
-        let inverses = BigNum::__batch_invert(inverses);
-
-        let mut result: AffineLinearExpressionTranscript<BigNum, NScalarSlices,NMuls,NAdds> = AffineLinearExpressionTranscript {
-            table_transcript: [[AffineTranscript::new(); 8]; NMuls],
-            msm_double_transcript: [[AffineTranscript::new(); 4]; NScalarSlices - 1],
-            msm_add_transcript: [[AffineTranscript::new(); NMuls]; NScalarSlices],
-            skew_transcript: [AffineTranscript::new(); NMuls],
-            add_transcript: [AffineTranscript::new(); NAdds],
-            offset_generator_transcript: AffineTranscript::new()
-        };
-
-        let mut it = 0;
-        for i in 0..NMuls {
-            for j in 0..8 {
-                result.table_transcript[i][j] = AffineTranscript::from_j_with_hint(jtranscript.table_transcript[i][j], inverses[it]);
-                it+=1;
-            }
-        }
-        for i in 0..NMuls {
-            result.msm_add_transcript[0][i] = AffineTranscript::from_j_with_hint(jtranscript.msm_add_transcript[0][i], inverses[it]);
-            it+=1;
-        }
-        for i in 1..NScalarSlices {
-            for j in 0..4 {
-                result.msm_double_transcript[i-1][j] = AffineTranscript::from_j_with_hint(jtranscript.msm_double_transcript[i-1][j], inverses[it]);
-                it+=1;
-            }
-
-            for j in 0..NMuls {
-                result.msm_add_transcript[i][j] = AffineTranscript::from_j_with_hint(jtranscript.msm_add_transcript[i][j], inverses[it]);
-                it+=1;
-            }
-        }
-
-        for i in 0..NMuls {
-            result.skew_transcript[i] = AffineTranscript::from_j_with_hint(jtranscript.skew_transcript[i], inverses[it]);
-            it+=1;
-        }
-        for i in 0..NAdds {
-            result.add_transcript[i] = AffineTranscript::from_j_with_hint(jtranscript.add_transcript[i], inverses[it]);
-            it+=1;
-        }
-
-        result.offset_generator_transcript = AffineTranscript::from_j_with_hint(jtranscript.offset_generator_transcript, inverses[it]);
-
-        result
+        (accumulator, affine_transcript)
     }
 }

--- a/src/curves.nr
+++ b/src/curves.nr
@@ -1,0 +1,10 @@
+pub(crate) mod pallas;
+pub(crate) mod vesta;
+pub(crate) mod bls12_377;
+pub(crate) mod bls12_381;
+pub(crate) mod secp256k1;
+pub(crate) mod secp256r1;
+pub(crate) mod secp384r1;
+pub(crate) mod mnt4_753;
+pub(crate) mod mnt6_753;
+pub(crate) mod bn254;

--- a/src/curves/bls12_377.nr
+++ b/src/curves/bls12_377.nr
@@ -1,0 +1,75 @@
+use dep::bignum::BigNum;
+use dep::bignum::fields::bls12_377Fq::BLS12_377_Fq_Params;
+use dep::bignum::fields::bls12_377Fr::BLS12_377_Fr_Params;
+use crate::CurveParamsTrait;
+use crate::BigCurve;
+use crate::scalar_field::ScalarField;
+
+global BLS12_377_SCALAR_SLICES = 64;
+pub struct BLS12_377_Params {}
+impl CurveParamsTrait<BigNum<4, BLS12_377_Fq_Params>> for BLS12_377_Params {
+    fn a() -> BigNum<4, BLS12_377_Fq_Params> {
+        BigNum { limbs: [0x00, 0x00, 0x00, 0x00] }
+    }
+    fn b() -> BigNum<4, BLS12_377_Fq_Params> {
+        BigNum { limbs: [0x01, 0x00, 0x00, 0x00] }
+    }
+    fn one() -> [BigNum<4, BLS12_377_Fq_Params>; 2] {
+        [
+            BigNum {
+                limbs: [
+                    0x481512ffcd394eeab9b16eb21be9ef, 0x1e2caa9d41bb188282c8bd37cb5cd5, 0xdefe740a67c8fc6225bf87ff548595, 0x8848
+                ]
+            }, BigNum {
+                limbs: [
+                    0xfe3d3634a9591afd82de55559c8ea6, 0xb348ca3e52d96d182ad44fb82305c2, 0x69c5102eff1f674f5d30afeec4bd7f, 0x01914a
+                ]
+            }
+        ]
+    }
+    fn offset_generator() -> [BigNum<4, BLS12_377_Fq_Params>; 2] {
+        [
+            BigNum {
+                limbs: [
+                    0xba342dd2e8a57e30e4fab3aac114b2, 0x6e7346ab4fea7f55a1f08939754a50, 0x6412e09f423388a318b8a4d36a0072, 0x3eb8
+                ]
+            }, BigNum {
+                limbs: [
+                    0x8a796bd31648b17a897fce57b28356, 0x2e1d2547bb3228e76b01175312545b, 0x9accab8b8165af3afa1a90cb152ecd, 0xa0e9
+                ]
+            }
+        ]
+    }
+    fn offset_generator_final() -> [BigNum<4, BLS12_377_Fq_Params>; 2] {
+        [
+            BigNum {
+                limbs: [
+                    0x671498ee656f13e9b769355538d6a5, 0x50f93aaeb8c9ffbd231d89d655a66e, 0xab51ed158495b9e4459d72be5ef856, 0x01ab35
+                ]
+            }, BigNum {
+                limbs: [
+                    0x7e1116c8a65727559685d7c70063ff, 0xf16bb13f725cac296ddbd1bd54515c, 0x892af9d72f0a7eeeee28cce211e07c, 0x9991
+                ]
+            }
+        ]
+    }
+}
+
+pub type BLS12_377 = BigCurve<BigNum<4, BLS12_377_Fq_Params>, BLS12_377_Params>;
+pub type BLS12_377Scalar = ScalarField<BLS12_377_SCALAR_SLICES>;
+pub type BLS12_377Fq = BigNum<4, BLS12_377_Fq_Params>;
+pub type BLS12_377Fr = BigNum<3, BLS12_377_Fr_Params>;
+
+mod test {
+    use dep::bignum::BigNum;
+    use crate::curves::bls12_377::BLS12_377_SCALAR_SLICES;
+    use dep::bignum::fields::bls12_377Fr::BLS12_377_Fr_Params;
+    #[test]
+fn test_bits() {
+        let x: BigNum<3, BLS12_377_Fr_Params> = BigNum::new();
+        let max_wnaf_bits: u32 = x.modulus_bits() + 1;
+
+        let scalar_slices = (max_wnaf_bits / 4) + (max_wnaf_bits % 4 != 0) as u32;
+        assert(scalar_slices == BLS12_377_SCALAR_SLICES);
+    }
+}

--- a/src/curves/bls12_381.nr
+++ b/src/curves/bls12_381.nr
@@ -1,0 +1,75 @@
+use dep::bignum::BigNum;
+use dep::bignum::fields::bls12_381Fq::BLS12_381_Fq_Params;
+use dep::bignum::fields::bls12_381Fr::BLS12_381_Fr_Params;
+use crate::CurveParamsTrait;
+use crate::BigCurve;
+use crate::scalar_field::ScalarField;
+
+global BLS12_381_SCALAR_SLICES = 64;
+pub struct BLS12_381_Params {}
+impl CurveParamsTrait<BigNum<4, BLS12_381_Fq_Params>> for BLS12_381_Params {
+    fn a() -> BigNum<4, BLS12_381_Fq_Params> {
+        BigNum { limbs: [0x00, 0x00, 0x00, 0x00] }
+    }
+    fn b() -> BigNum<4, BLS12_381_Fq_Params> {
+        BigNum { limbs: [0x04, 0x00, 0x00, 0x00] }
+    }
+    fn one() -> [BigNum<4, BLS12_381_Fq_Params>; 2] {
+        [
+            BigNum {
+                limbs: [
+                    0x55e83ff97a1aeffb3af00adb22c6bb, 0x8c4f9774b905a14e3a3f171bac586c, 0xa73197d7942695638c4fa9ac0fc368, 0x17f1d3
+                ]
+            }, BigNum {
+                limbs: [
+                    0x3cc744a2888ae40caa232946c5e7e1, 0xe095d5d00af600db18cb2c04b3edd0, 0x81e3aaa0f1a09e30ed741d8ae4fcf5, 0x08b3f4
+                ]
+            }
+        ]
+    }
+    fn offset_generator() -> [BigNum<4, BLS12_381_Fq_Params>; 2] {
+        [
+            BigNum {
+                limbs: [
+                    0xcaa8bd3652a69894c3e8ce75bd7de0, 0x921cf06eacb00767c6aa2186d51836, 0xf00e268786f3d4f245e1afd2b99cbf, 0x1660ef
+                ]
+            }, BigNum {
+                limbs: [
+                    0xdf7b66a7f319b3af6961dd328b5691, 0x3debb030dcfa8fd697ac3704931596, 0xc1a488f265da2fc98fa92f57698a23, 0x054b43
+                ]
+            }
+        ]
+    }
+    fn offset_generator_final() -> [BigNum<4, BLS12_381_Fq_Params>; 2] {
+        [
+            BigNum {
+                limbs: [
+                    0xe3a05fbbe9bd6bb2669ccc7a7c81c4, 0xfdd0554fc1ae7ef6bae1896afe2dd1, 0xa5d836272c350f0590344fb99b61c7, 0x0efaeb
+                ]
+            }, BigNum {
+                limbs: [
+                    0x1b17500cfb60985fc0834ca89b798c, 0x76fe94b37e801b6b8d582c683bd931, 0xa5e501f313de4014dd33cbdcb16653, 0x0e1da3
+                ]
+            }
+        ]
+    }
+}
+
+pub type BLS12_381 = BigCurve<BigNum<4, BLS12_381_Fq_Params>, BLS12_381_Params>;
+pub type BLS12_381Scalar = ScalarField<BLS12_381_SCALAR_SLICES>;
+pub type BLS12_381Fq = BigNum<4, BLS12_381_Fq_Params>;
+pub type BLS12_381Fr = BigNum<3, BLS12_381_Fr_Params>;
+
+mod test {
+    use dep::bignum::BigNum;
+    use crate::curves::bls12_381::BLS12_381_SCALAR_SLICES;
+    use dep::bignum::fields::bls12_381Fr::BLS12_381_Fr_Params;
+    #[test]
+fn test_bits() {
+        let x: BigNum<3, BLS12_381_Fr_Params> = BigNum::new();
+        let max_wnaf_bits: u32 = x.modulus_bits() + 1;
+
+        let scalar_slices = (max_wnaf_bits / 4) + (max_wnaf_bits % 4 != 0) as u32;
+        assert(scalar_slices == BLS12_381_SCALAR_SLICES);
+    }
+}

--- a/src/curves/bn254.nr
+++ b/src/curves/bn254.nr
@@ -1,0 +1,47 @@
+use dep::bignum::BigNum;
+use dep::bignum::fields::bn254Fq::BNParams;
+use crate::CurveParamsTrait;
+use crate::BigCurve;
+use crate::scalar_field::ScalarField;
+
+pub struct BN254Params {}
+impl CurveParamsTrait<BigNum<3, BNParams>> for BN254Params {
+    fn a() -> BigNum<3, BNParams> {
+        BigNum { limbs: [0x00, 0x00, 0x00] }
+    }
+    fn b() -> BigNum<3, BNParams> {
+        BigNum { limbs: [0x03, 0x00, 0x00] }
+    }
+    fn one() -> [BigNum<3, BNParams>; 2] {
+        [BigNum { limbs: [0x01, 0x00, 0x00] }, BigNum { limbs: [0x02, 0x00, 0x00] }]
+    }
+    fn offset_generator() -> [BigNum<3, BNParams>; 2] {
+        [
+            BigNum { limbs: [0x377f339fa8372d1d3adc42a3d4901c, 0x96cbfde252d4502d20fe63e6eb2b52, 0x0666] }, BigNum { limbs: [0x06d5ac65dd163514b69bb7b45a8c52, 0xa20295561f2b500335be517e2f9ddf, 0x1390] }
+        ]
+    }
+    fn offset_generator_final() -> [BigNum<3, BNParams>; 2] {
+        [
+            BigNum { limbs: [0x876f472cd3289fef9f11dc404e447f, 0x7b083434c2a69effc4cb7fce9fecb6, 0x0336] }, BigNum { limbs: [0xa33149d0f82e5335a130fd3baf1bf4, 0x37bbf991eefb0b04d52e689358228b, 0x178e] }
+        ]
+    }
+}
+
+global BN254_SCALAR_SLICES = 64;
+pub type BN254 = BigCurve<BigNum<3, BNParams>, BN254Params>;
+pub type BN254Scalar = ScalarField<BN254_SCALAR_SLICES>;
+pub type BN254Fq = BigNum<3, BNParams>;
+// pub type Secp256r1Fr = BigNum<3, Secp256r1_Fr_Params>;
+
+// mod test {
+//     use dep::bignum::BigNum;
+//     use crate::curves::secp256r1::SECP256r1_SCALAR_SLICES;
+//     #[test]
+// fn test_bits() {
+//         let x: BigNum<3, BNParams> = BigNum::new();
+//         let max_wnaf_bits: u32 = x.modulus_bits() + 1;
+
+//         let scalar_slices = (max_wnaf_bits / 4) + (max_wnaf_bits % 4 != 0) as u32;
+//         assert(scalar_slices == SECP256r1_SCALAR_SLICES);
+//     }
+// }

--- a/src/curves/mnt4_753.nr
+++ b/src/curves/mnt4_753.nr
@@ -1,0 +1,79 @@
+use dep::bignum::BigNum;
+use dep::bignum::fields::mnt4_753Fq::MNT4_753_Fq_Params;
+use dep::bignum::fields::mnt4_753Fr::MNT4_753_Fr_Params;
+use crate::CurveParamsTrait;
+use crate::BigCurve;
+use crate::scalar_field::ScalarField;
+
+global MNT4_753_SCALAR_SLICES = 189;
+pub struct MNT4_753_Params {}
+impl CurveParamsTrait<BigNum<7, MNT4_753_Fq_Params>> for MNT4_753_Params {
+    fn a() -> BigNum<7, MNT4_753_Fq_Params> {
+        BigNum { limbs: [0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00] }
+    }
+    fn b() -> BigNum<7, MNT4_753_Fq_Params> {
+        BigNum {
+            limbs: [
+                0xad265458e06372009c9a0491678ef4, 0x773111c36c8b1b4e8f1ece940ef9ea, 0xc3d8bb21c8d68bb8cfb9db4b8c8fba, 0xa92c78dc537e51a16703ec9855c77f, 0x051c596560835df0c9e50a5b59b882, 0xc9dcae7a016ac5d7748d3313cd8e39, 0x01373684a8
+            ]
+        }
+    }
+    fn one() -> [BigNum<7, MNT4_753_Fq_Params>; 2] {
+        [
+            BigNum {
+                limbs: [
+                    0xc2ab23be1c24740af0fdeb3b7f1981, 0xfeff338dd73a5a7eeecfbce7cf95d3, 0x463d98a4ea009d57aad9716f708885, 0x6d1ef781d1de4ffb1f806b314c5ad3, 0xefa5546444d40c82d6a271f1a43862, 0x450bb76a02d86daaffbaeb69995eb9, 0x542f1dad
+                ]
+            }, BigNum {
+                limbs: [
+                    0x031ea99cff05e05ec3be2e4a050358, 0x23036db8fb990a342449caeb92fa6b, 0x5dea57ef53ee29157bdf1b741aebd4, 0xee5599dd7c3dfa4100284833115aec, 0x7fddcdea19cb10b2bf61f37ae2c456, 0x26e257b175ae94deb9e10aba4ba72f, 0x4ab64735
+                ]
+            }
+        ]
+    }
+    fn offset_generator() -> [BigNum<7, MNT4_753_Fq_Params>; 2] {
+        [
+            BigNum {
+                limbs: [
+                    0x626a3f756e21d88542b02626edba28, 0x4e5fcb24def435b831b168d03ffa17, 0x37176e9c4f71cf8b3d7dd158ff79d6, 0x02a27192bd63ff0ae75b427f371e0f, 0x19d7d1a5ec40d8c9e958c8ff2851b5, 0x4f67020973b5ef46536489d2168c1d, 0x0165cd5cb7
+                ]
+            }, BigNum {
+                limbs: [
+                    0xa30942007a5fd26683b2666547b8ac, 0x2b81278933c31d48aedf581d9cc73f, 0xd4a7583126a808f4f6b39b9fab6392, 0x6dd10e9d210364c99c4313dc900447, 0xff95481ef076765ab79c10181db9d9, 0x524ad0a6e34b47375458acac5dfb50, 0xd39ff56b
+                ]
+            }
+        ]
+    }
+    fn offset_generator_final() -> [BigNum<7, MNT4_753_Fq_Params>; 2] {
+        [
+            BigNum {
+                limbs: [
+                    0xa58e0356b1875bb057efadc335d7ef, 0xf9f6bb7070e70c1f52aa90c2eea40b, 0x79f3748370ac445ba29c746935278f, 0x2583c367ac3bf38902abcbd7d1f96b, 0xb0d541577618ab033e51c0197e9892, 0xa1defaff53c883c79edd0f16db9cb7, 0x976315b5
+                ]
+            }, BigNum {
+                limbs: [
+                    0x09a86892894b8aa69ee96bf1fc249e, 0x53fe404e91c85ad0f982aa10a9d9d8, 0x424af093cf222be97190fecb7e9f8b, 0x63e2ab17ef6aa3fb2db6bed30f61f0, 0x7e39a85475a73215ab0576a69ab318, 0x87258dcaaec7d994b10b88828830c5, 0x01215baa38
+                ]
+            }
+        ]
+    }
+}
+
+pub type MNT4_753 = BigCurve<BigNum<7, MNT4_753_Fq_Params>, MNT4_753_Params>;
+pub type MNT4_753Scalar = ScalarField<MNT4_753_SCALAR_SLICES>;
+pub type MNT4_753Fq = BigNum<7, MNT4_753_Fq_Params>;
+pub type MNT4_753Fr = BigNum<7, MNT4_753_Fr_Params>;
+
+mod test {
+    use dep::bignum::BigNum;
+    use crate::curves::mnt4_753::MNT4_753_SCALAR_SLICES;
+    use dep::bignum::fields::mnt4_753Fr::MNT4_753_Fr_Params;
+    #[test]
+fn test_bits() {
+        let x: BigNum<7, MNT4_753_Fr_Params> = BigNum::new();
+        let max_wnaf_bits: u32 = x.modulus_bits() + 1;
+
+        let scalar_slices = (max_wnaf_bits / 4) + (max_wnaf_bits % 4 != 0) as u32;
+        assert(scalar_slices == MNT4_753_SCALAR_SLICES);
+    }
+}

--- a/src/curves/mnt6_753.nr
+++ b/src/curves/mnt6_753.nr
@@ -1,0 +1,79 @@
+use dep::bignum::BigNum;
+use dep::bignum::fields::mnt6_753Fq::MNT6_753_Fq_Params;
+use dep::bignum::fields::mnt6_753Fr::MNT6_753_Fr_Params;
+use crate::CurveParamsTrait;
+use crate::BigCurve;
+use crate::scalar_field::ScalarField;
+
+global MNT6_753_SCALAR_SLICES = 189;
+pub struct MNT6_753_Params {}
+impl CurveParamsTrait<BigNum<7, MNT6_753_Fq_Params>> for MNT6_753_Params {
+    fn a() -> BigNum<7, MNT6_753_Fq_Params> {
+        BigNum { limbs: [0x0b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00] }
+    }
+    fn b() -> BigNum<7, MNT6_753_Fq_Params> {
+        BigNum {
+            limbs: [
+                0xba7505ba6fcf2485540b13dfc8468a, 0xf9a80a95f401867c4e80f4747fde5a, 0x0fcf2c43d7bf847957c34cca1e3585, 0xb7985993f62f03b22a9a3c737a1a1e, 0xbb64b2bb01b10e60a5d5dfe0a25714, 0x0863c79d56446237ce2e1468d14ae9, 0x7da285e7
+            ]
+        }
+    }
+    fn one() -> [BigNum<7, MNT6_753_Fq_Params>; 2] {
+        [
+            BigNum {
+                limbs: [
+                    0x329a6fefa9a1f3f7a1fbd93a7bffb8, 0x1acbf7da60895b8b3d9d442c4c4123, 0xe5e3c57b6df120cee3cd9d867e66d1, 0x0c0d5fc5e818771b931f1d5bdd069c, 0x131c2437e884c4997fd1dcb409367d, 0x6e831147412cfb1002284f30338088, 0x255f8e87
+                ]
+            }, BigNum {
+                limbs: [
+                    0x521df9855687139f0c51754c0ccc49, 0x4d9992f5cbf4b2cc4c42eff9a5a6c4, 0x0dc7a593cce5a792e94d0020c335b7, 0x4c7a18ed9c4bd3c7ed0ffb31c57e61, 0x2a3585bdd6d7722c6c07d7873bb02d, 0x6e2eb3fca70dc1063bac3455180120, 0x0128c02fff
+                ]
+            }
+        ]
+    }
+    fn offset_generator() -> [BigNum<7, MNT6_753_Fq_Params>; 2] {
+        [
+            BigNum {
+                limbs: [
+                    0xbb4565362dd76213944028a2a0e5ea, 0xfed0b9b23c677643d8db909425432b, 0x25b23be14aab3c446c44c012ec7050, 0x3049e8844b5e37006d0684f0f9579a, 0x0aabcf62121623ec2ac0a16c581755, 0xbf7cf3e3f525f8526e24d643d064b6, 0x0167e7d28f
+                ]
+            }, BigNum {
+                limbs: [
+                    0x0c8c53994efc3a69348f0a7d870a94, 0xc74050c9446ac84b471bdfdb879bc9, 0x2e42983e32c0ca65bab6e0f78b6771, 0x4f88b5a3027c83bbed00a6ee180197, 0xd62eaaa6ef628d6e8a422176080efb, 0x47c818f5714e899c83a6d54893f252, 0x011008d2e6
+                ]
+            }
+        ]
+    }
+    fn offset_generator_final() -> [BigNum<7, MNT6_753_Fq_Params>; 2] {
+        [
+            BigNum {
+                limbs: [
+                    0x5b6ad7b65e3a86239c2efbdb300b8d, 0x7d06f1a94609f8e4eb48c998d1571d, 0x95a74f11f2fb5be7544da5c184e38d, 0x600f8f2fdcd5e802342ebe03c3787f, 0xc3fa8f3f017c7aed50e1a14b78f3b3, 0xe7f3b2638fa13f65670c15eb006e99, 0x016389a6fb
+                ]
+            }, BigNum {
+                limbs: [
+                    0x42eb137506b02f7665ebbe0211b768, 0x814148c3996475176b11c4db1d356a, 0xf97e6cd350259b5456471a2237553f, 0x5c822035f3f7c21fc2e6f9aac5945a, 0xa319d0923fc0ac9db23b819dcb7371, 0xa4186459f74d57db479c998a5db03a, 0x7f824db1
+                ]
+            }
+        ]
+    }
+}
+
+pub type MNT6_753 = BigCurve<BigNum<7, MNT6_753_Fq_Params>, MNT6_753_Params>;
+pub type MNT6_753Scalar = ScalarField<MNT6_753_SCALAR_SLICES>;
+pub type MNT6_753Fq = BigNum<7, MNT6_753_Fq_Params>;
+pub type MNT6_753Fr = BigNum<7, MNT6_753_Fr_Params>;
+
+mod test {
+    use dep::bignum::BigNum;
+    use crate::curves::mnt6_753::MNT6_753_SCALAR_SLICES;
+    use dep::bignum::fields::mnt6_753Fr::MNT6_753_Fr_Params;
+    #[test]
+fn test_bits() {
+        let x: BigNum<7, MNT6_753_Fr_Params> = BigNum::new();
+        let max_wnaf_bits: u32 = x.modulus_bits() + 1;
+
+        let scalar_slices = (max_wnaf_bits / 4) + (max_wnaf_bits % 4 != 0) as u32;
+        assert(scalar_slices == MNT6_753_SCALAR_SLICES);
+    }
+}

--- a/src/curves/pallas.nr
+++ b/src/curves/pallas.nr
@@ -1,0 +1,52 @@
+use dep::bignum::BigNum;
+use dep::bignum::fields::pallasFr::Pallas_Fr_Params;
+use dep::bignum::fields::pallasFq::Pallas_Fq_Params;
+use crate::BigCurve;
+use crate::scalar_field::ScalarField;
+use crate::CurveParamsTrait;
+
+global PALLAS_SCALAR_SLICES = 64;
+
+pub struct Pallas_Params {}
+impl CurveParamsTrait<BigNum<3, Pallas_Fq_Params>> for Pallas_Params {
+    fn a() -> BigNum<3, Pallas_Fq_Params> {
+        BigNum { limbs: [0x00, 0x00, 0x00] }
+    }
+    fn b() -> BigNum<3, Pallas_Fq_Params> {
+        BigNum { limbs: [0x05, 0x00, 0x00] }
+    }
+    fn one() -> [BigNum<3, Pallas_Fq_Params>; 2] {
+        [
+            BigNum { limbs: [0x4698fc094cf91b992d30ed00000000, 0x22, 0x4000] }, BigNum { limbs: [0x02, 0x00, 0x00] }
+        ]
+    }
+    fn offset_generator() -> [BigNum<3, Pallas_Fq_Params>; 2] {
+        [
+            BigNum { limbs: [0xd2422812b398350c1aebba48ec188a, 0xb131381b40fe8f0a2a6379eb41d224, 0x241a] }, BigNum { limbs: [0x0b9046b0869b1629091d1fa9f16692, 0xc5dec5f6d150a01e8529316736e0fa, 0x2c49] }
+        ]
+    }
+    fn offset_generator_final() -> [BigNum<3, Pallas_Fq_Params>; 2] {
+        [
+            BigNum { limbs: [0x8d735ee60f0b794209ba47e69517b5, 0x0268fe41698522f06c1f464e5425f6, 0x1e33] }, BigNum { limbs: [0xbd45401bf9c27bf9dd24a5ce54ce87, 0x47abf9cd0515d86bf76d53b264cfcc, 0x072a] }
+        ]
+    }
+}
+
+pub type Pallas = BigCurve<BigNum<3, Pallas_Fq_Params>, Pallas_Params>;
+pub type PallasScalar = ScalarField<PALLAS_SCALAR_SLICES>;
+pub type PallasFq = BigNum<3, Pallas_Fq_Params>;
+pub type PallasFr = BigNum<3, Pallas_Fr_Params>;
+
+mod test {
+    use dep::bignum::BigNum;
+    use crate::curves::pallas::PALLAS_SCALAR_SLICES;
+    use dep::bignum::fields::pallasFr::Pallas_Fr_Params;
+    #[test]
+fn test_bits() {
+        let x: BigNum<3, Pallas_Fr_Params> = BigNum::new();
+        let max_wnaf_bits: u32 = x.modulus_bits() + 1;
+
+        let scalar_slices = (max_wnaf_bits / 4) + (max_wnaf_bits % 4 != 0) as u32;
+        assert(scalar_slices == PALLAS_SCALAR_SLICES);
+    }
+}

--- a/src/curves/secp256k1.nr
+++ b/src/curves/secp256k1.nr
@@ -1,0 +1,51 @@
+use dep::bignum::BigNum;
+use dep::bignum::fields::secp256k1Fq::Secp256k1_Fq_Params;
+use dep::bignum::fields::secp256k1Fr::Secp256k1_Fr_Params;
+use crate::CurveParamsTrait;
+use crate::BigCurve;
+use crate::scalar_field::ScalarField;
+
+global SECP256k1_SCALAR_SLICES = 65;
+pub struct Secp256k1_Params {}
+impl CurveParamsTrait<BigNum<3, Secp256k1_Fq_Params>> for Secp256k1_Params {
+    fn a() -> BigNum<3, Secp256k1_Fq_Params> {
+        BigNum { limbs: [0x00, 0x00, 0x00] }
+    }
+    fn b() -> BigNum<3, Secp256k1_Fq_Params> {
+        BigNum { limbs: [0x07, 0x00, 0x00] }
+    }
+    fn one() -> [BigNum<3, Secp256k1_Fq_Params>; 2] {
+        [
+            BigNum { limbs: [0x9bfcdb2dce28d959f2815b16f81798, 0x667ef9dcbbac55a06295ce870b0702, 0x79be] }, BigNum { limbs: [0x17b448a68554199c47d08ffb10d4b8, 0xda7726a3c4655da4fbfc0e1108a8fd, 0x483a] }
+        ]
+    }
+    fn offset_generator() -> [BigNum<3, Secp256k1_Fq_Params>; 2] {
+        [
+            BigNum { limbs: [0x7f497cc0b274831d60a9a05d29677e, 0x08726557bf1dd4a0bfdc80ba0f6f13, 0x9046] }, BigNum { limbs: [0xfc449b9f63f4ec1c94bd9e3d802229, 0x63b03856445a4b7d349c9a184f81ac, 0x8d48] }
+        ]
+    }
+    fn offset_generator_final() -> [BigNum<3, Secp256k1_Fq_Params>; 2] {
+        [
+            BigNum { limbs: [0x36e6c375bf85dd5b9f64e908eedd44, 0xddca5c990b1b1000dfc199cb21c0e9, 0xd913] }, BigNum { limbs: [0xf863897dd8147d74af6c9b62d49be6, 0xc1388d9280f314b0acd7fb4ce979b9, 0x2bf7] }
+        ]
+    }
+}
+
+pub type Secp256k1 = BigCurve<BigNum<3, Secp256k1_Fq_Params>, Secp256k1_Params>;
+pub type Secp256k1Scalar = ScalarField<SECP256k1_SCALAR_SLICES>;
+pub type Secp256k1Fq = BigNum<3, Secp256k1_Fq_Params>;
+pub type Secp256k1Fr = BigNum<3, Secp256k1_Fr_Params>;
+
+mod test {
+    use dep::bignum::BigNum;
+    use crate::curves::secp256k1::SECP256k1_SCALAR_SLICES;
+    use dep::bignum::fields::secp256k1Fr::Secp256k1_Fr_Params;
+    #[test]
+fn test_bits() {
+        let x: BigNum<3, Secp256k1_Fr_Params> = BigNum::new();
+        let max_wnaf_bits: u32 = x.modulus_bits() + 1;
+
+        let scalar_slices = (max_wnaf_bits / 4) + (max_wnaf_bits % 4 != 0) as u32;
+        assert(scalar_slices == SECP256k1_SCALAR_SLICES);
+    }
+}

--- a/src/curves/secp256r1.nr
+++ b/src/curves/secp256r1.nr
@@ -1,0 +1,51 @@
+use dep::bignum::BigNum;
+use dep::bignum::fields::secp256r1Fq::Secp256r1_Fq_Params;
+use dep::bignum::fields::secp256r1Fr::Secp256r1_Fr_Params;
+use crate::CurveParamsTrait;
+use crate::BigCurve;
+use crate::scalar_field::ScalarField;
+
+pub struct Secp256r1_Params {}
+impl CurveParamsTrait<BigNum<3, Secp256r1_Fq_Params>> for Secp256r1_Params {
+    fn a() -> BigNum<3, Secp256r1_Fq_Params> {
+        BigNum { limbs: [0xfffffffffffffffffffffffc, 0xffff00000001000000000000000000, 0xffff] }
+    }
+    fn b() -> BigNum<3, Secp256r1_Fq_Params> {
+        BigNum { limbs: [0x1d06b0cc53b0f63bce3c3e27d2604b, 0x35d8aa3a93e7b3ebbd55769886bc65, 0x5ac6] }
+    }
+    fn one() -> [BigNum<3, Secp256r1_Fq_Params>; 2] {
+        [
+            BigNum { limbs: [0x037d812deb33a0f4a13945d898c296, 0xd1f2e12c4247f8bce6e563a440f277, 0x6b17] }, BigNum { limbs: [0xce33576b315ececbb6406837bf51f5, 0x42e2fe1a7f9b8ee7eb4a7c0f9e162b, 0x4fe3] }
+        ]
+    }
+    fn offset_generator() -> [BigNum<3, Secp256r1_Fq_Params>; 2] {
+        [
+            BigNum { limbs: [0x43a84352fdbca907cb6bcdc31f4784, 0x02b728fe767007b08d0ced4ccf0591, 0x5c14] }, BigNum { limbs: [0x664a12c8ee78446ee947a8a109adfe, 0x445dd71ff484b877a5bf3df6263bfc, 0x841b] }
+        ]
+    }
+    fn offset_generator_final() -> [BigNum<3, Secp256r1_Fq_Params>; 2] {
+        [
+            BigNum { limbs: [0x4e53e542bc502419d0cb4b99c0aa48, 0x74d3a045b26542b1a5931d721650ab, 0x6982] }, BigNum { limbs: [0xbe3c1ef0581c8f76517e499277b269, 0xfd562740986614ce3b7025c0dfb8aa, 0xfc88] }
+        ]
+    }
+}
+
+pub global SECP256r1_SCALAR_SLICES: u32 = 65;
+pub type Secp256r1 = BigCurve<BigNum<3, Secp256r1_Fq_Params>, Secp256r1_Params>;
+pub type Secp256r1Scalar = ScalarField<SECP256r1_SCALAR_SLICES>;
+pub type Secp256r1Fq = BigNum<3, Secp256r1_Fq_Params>;
+pub type Secp256r1Fr = BigNum<3, Secp256r1_Fr_Params>;
+
+mod test {
+    use dep::bignum::BigNum;
+    use crate::curves::secp256r1::SECP256r1_SCALAR_SLICES;
+    use dep::bignum::fields::secp256r1Fr::Secp256r1_Fr_Params;
+    #[test]
+fn test_bits() {
+        let x: BigNum<3, Secp256r1_Fr_Params> = BigNum::new();
+        let max_wnaf_bits: u32 = x.modulus_bits() + 1;
+
+        let scalar_slices = (max_wnaf_bits / 4) + (max_wnaf_bits % 4 != 0) as u32;
+        assert(scalar_slices == SECP256r1_SCALAR_SLICES);
+    }
+}

--- a/src/curves/secp384r1.nr
+++ b/src/curves/secp384r1.nr
@@ -1,0 +1,87 @@
+use dep::bignum::BigNum;
+use dep::bignum::fields::secp384r1Fq::Secp384r1_Fq_Params;
+use dep::bignum::fields::secp384r1Fr::Secp384r1_Fr_Params;
+use crate::CurveParamsTrait;
+use crate::BigCurve;
+use crate::scalar_field::ScalarField;
+
+pub struct Secp384r1_Params {}
+impl CurveParamsTrait<BigNum<4, Secp384r1_Fq_Params>> for Secp384r1_Params {
+    fn a() -> BigNum<4, Secp384r1_Fq_Params> {
+        BigNum {
+            limbs: [
+                0xffffff0000000000000000fffffffc, 0xfffffffffffffffffffffffffffeff, 0xffffffffffffffffffffffffffffff, 0xffffff
+            ]
+        }
+    }
+    fn b() -> BigNum<4, Secp384r1_Fq_Params> {
+        BigNum {
+            limbs: [
+                0x56398d8a2ed19d2a85c8edd3ec2aef, 0x9c6efe8141120314088f5013875ac6, 0xa7e23ee7e4988e056be3f82d19181d, 0xb3312f
+            ]
+        }
+    }
+    fn one() -> [BigNum<4, Secp384r1_Fq_Params>; 2] {
+        [
+            BigNum {
+                limbs: [
+                    0x02f25dbf55296c3a545e3872760ab7, 0x3b628ba79b9859f741e082542a3855, 0x22be8b05378eb1c71ef320ad746e1d, 0xaa87ca
+                ]
+            }, BigNum {
+                limbs: [
+                    0x60b1ce1d7e819d7a431d7c90ea0e5f, 0x1dbd289a147ce9da3113b5f0b8c00a, 0x4a96262c6f5d9e98bf9292dc29f8f4, 0x3617de
+                ]
+            }
+        ]
+    }
+    fn offset_generator() -> [BigNum<4, Secp384r1_Fq_Params>; 2] {
+        [
+            BigNum {
+                limbs: [
+                    0xba62f5015d975e9c847349dc8a58f7, 0xcfe0a3905b8dafff0226cbfddee8d3, 0xce72424b249140226ac9b8afb0ab3c, 0xffb219
+                ]
+            }, BigNum {
+                limbs: [
+                    0x889e51064a7515c4b3a96a397501de, 0xfe7bbfa55a3b86cf38c1e0bce169de, 0xb19d05c22e1590952e5a956ddcb3bd, 0x462005
+                ]
+            }
+        ]
+    }
+    fn offset_generator_final() -> [BigNum<4, Secp384r1_Fq_Params>; 2] {
+        [
+            BigNum {
+                limbs: [
+                    0xce701d9971f92d5e54d393c5e68585, 0x7075dbe299c8708a1e0ec78c96a60f, 0x393d1f969e37931c99fb298e53630d, 0x364fe7
+                ]
+            }, BigNum {
+                limbs: [
+                    0x8301c0d245c908e4f5c4e20c98a696, 0xb48327458c410785bab4bd29b71040, 0xe9536dfb1bd0b1c80c04e2e1ef404e, 0x40d30a
+                ]
+            }
+        ]
+    }
+}
+
+pub global SECP384r1_SCALAR_SLICES = 97;
+pub type Secp384r1 = BigCurve<BigNum<4, Secp384r1_Fq_Params>, Secp384r1_Params>;
+pub type Secp384r1Scalar = ScalarField<SECP384r1_SCALAR_SLICES>;
+pub type Secp384r1Fq = BigNum<4, Secp384r1_Fq_Params>;
+pub type Secp384r1Fr = BigNum<4, Secp384r1_Fr_Params>;
+
+mod test {
+    use dep::bignum::BigNum;
+    use crate::scalar_field::ScalarField;
+    use crate::curves::secp384r1::Secp384r1Scalar;
+    use dep::bignum::fields::secp384r1Fr::Secp384r1_Fr_Params;
+    
+    #[test]
+fn test_bits() {
+        let x: BigNum<4, Secp384r1_Fr_Params> = BigNum::new();
+        let max_wnaf_bits: u32 = x.modulus_bits() + 1;
+
+        let scalar_slices = (max_wnaf_bits / 4) + (max_wnaf_bits % 4 != 0) as u32;
+        let scalar: Secp384r1Scalar = ScalarField::zero();
+        let expected = scalar.len();
+        assert(scalar_slices == expected);
+    }
+}

--- a/src/curves/vesta.nr
+++ b/src/curves/vesta.nr
@@ -1,0 +1,51 @@
+use dep::bignum::BigNum;
+use dep::bignum::fields::vestaFq::Vesta_Fq_Params;
+use dep::bignum::fields::vestaFr::Vesta_Fr_Params;
+use crate::CurveParamsTrait;
+use crate::BigCurve;
+use crate::scalar_field::ScalarField;
+
+pub struct Vesta_Params {}
+impl CurveParamsTrait<BigNum<3, Vesta_Fq_Params>> for Vesta_Params {
+    fn a() -> BigNum<3, Vesta_Fq_Params> {
+        BigNum { limbs: [0x00, 0x00, 0x00] }
+    }
+    fn b() -> BigNum<3, Vesta_Fq_Params> {
+        BigNum { limbs: [0x05, 0x00, 0x00] }
+    }
+    fn one() -> [BigNum<3, Vesta_Fq_Params>; 2] {
+        [
+            BigNum { limbs: [0x4698fc0994a8dd8c46eb2100000000, 0x22, 0x4000] }, BigNum { limbs: [0x02, 0x00, 0x00] }
+        ]
+    }
+    fn offset_generator() -> [BigNum<3, Vesta_Fq_Params>; 2] {
+        [
+            BigNum { limbs: [0xd6286ae8e92203a8122b1827a9b6d1, 0xcd21322ea03ceea814cfd7137b4a13, 0x0116] }, BigNum { limbs: [0x6c4531e4384d03f3c0febb060cbe74, 0xabaae719efbfcf4a24508d1596c758, 0x2190] }
+        ]
+    }
+    fn offset_generator_final() -> [BigNum<3, Vesta_Fq_Params>; 2] {
+        [
+            BigNum { limbs: [0xa87902cfed63db9fdaa5a570a4938d, 0x1d99860422926bca663f59f047ce18, 0x1083] }, BigNum { limbs: [0x9fa3943f857b1178d7242101da6c4c, 0xa67fd5354fcf62d204d7ad617adb6c, 0x0a9f] }
+        ]
+    }
+}
+
+pub global VESTA_SCALAR_SLICES = 64;
+pub type Vesta = BigCurve<BigNum<3, Vesta_Fq_Params>, Vesta_Params>;
+pub type VestaScalar = ScalarField<VESTA_SCALAR_SLICES>;
+pub type VestaFq = BigNum<3, Vesta_Fq_Params>;
+pub type VestaFr = BigNum<3, Vesta_Fr_Params>;
+
+mod test {
+    use dep::bignum::BigNum;
+    use crate::curves::vesta::VESTA_SCALAR_SLICES;
+    use dep::bignum::fields::vestaFr::Vesta_Fr_Params;
+    #[test]
+fn test_bits() {
+        let x: BigNum<3, Vesta_Fr_Params> = BigNum::new();
+        let max_wnaf_bits: u32 = x.modulus_bits() + 1;
+
+        let scalar_slices = (max_wnaf_bits / 4) + (max_wnaf_bits % 4 != 0) as u32;
+        assert(scalar_slices == VESTA_SCALAR_SLICES);
+    }
+}

--- a/src/lib.nr
+++ b/src/lib.nr
@@ -1,20 +1,163 @@
-mod scalar_field;
-mod curve_jac;
+pub(crate) mod scalar_field;
+pub(crate) mod curve_jac;
 mod test_data;
 mod bigcurve_test;
+pub(crate) mod utils;
+pub(crate) mod curves;
 
 use dep::bignum::BigNum;
 
 use crate::scalar_field::ScalarField;
 use crate::curve_jac::AffineTranscript;
-use crate::curve_jac::AffineLinearExpressionTranscript;
 use crate::curve_jac::CurveJ;
+use crate::utils::hash_to_curve::hash_to_curve;
+
 use dep::bignum::BigNumTrait;
 
+use dep::sort::sort_advanced;
+fn __sort_field_as_u32(lhs: Field, rhs: Field) -> bool {
+    lhs as u32 < rhs as u32
+}
+
+fn assert_sorted(lhs: Field, rhs: Field) {
+    let result = (rhs - lhs - 1);
+    result.assert_max_bit_size(32);
+}
+
+struct SparseLookup<let N: u32> {
+    keys: [Field; N],
+    values: [Field; N],
+    maximum: Field // can be up to 2^32
+}
+
+/**
+ * @brief records data used to reason about whether a key exists in a json blob
+ **/
+struct KeySearchResult {
+    found: bool, // does the key exist?
+    target_lt_smallest_entry: bool, // is the target keyhash smaller than the smallest keyhash in self.key_hashes?
+    target_gt_largest_entry: bool, // is the target keyhash larger than the largest keyhash in self.key_hashes?
+    lhs_index: Field, // either the index of the key being searched for, or the index of the keyhash in self.key_hashes that is closest to keyhash (hash > lhs_index_hash)
+    rhs_index: Field, // either the index of the key being searched for, or the index of the keyhash in self.key_hashes that is closest to keyhash (hash < rhs_index_hash)
+}
+
+impl<let N: u32> SparseLookup<N> {
+    fn create(_keys: [Field; N], _values: [Field; N], _maximum: Field) -> Self {
+        let mut r: Self = SparseLookup { keys: [0; N], values: [0; N], maximum: _maximum };
+        let sorted_keys = sort_advanced(_keys, __sort_field_as_u32, assert_sorted);
+        r.keys = sorted_keys.sorted;
+        for i in 0..N {
+            r.values[i] = _values[sorted_keys.sort_indices[i]];
+        }
+        _maximum.assert_max_bit_size(32);
+        r
+    }
+
+    unconstrained fn search_for_key_in_map(self, target: Field) -> KeySearchResult {
+        let mut found_index: Field = 0;
+        let mut found: bool = false;
+
+        let mut lhs_maximum: Field = 0;
+        let mut rhs_minimum: Field = -1;
+        let mut lhs_maximum_index: Field = 0;
+        let mut rhs_minimum_index: Field = 0;
+        for i in 0..N {
+            let key= self.keys[i];
+            if (key == target) {
+                found_index = i as Field;
+                found = true;
+                break;
+            } else {
+                if key.lt(target) & (lhs_maximum.lt(key)) {
+                    lhs_maximum = key;
+                    lhs_maximum_index = i as Field;
+                }
+                if (target.lt(key)) & (key.lt(rhs_minimum)) {
+                    rhs_minimum = key;
+                    rhs_minimum_index = i as Field;
+                }
+            }
+        }
+        let target_lt_smallest_entry = target.lt(self.keys[0]);
+        let target_gt_largest_entry = self.keys[N - 1].lt(target);
+
+        let result_not_first_or_last = !target_lt_smallest_entry & !target_gt_largest_entry & !found;
+
+        let mut lhs_index = result_not_first_or_last as Field * lhs_maximum_index;
+        let mut rhs_index = result_not_first_or_last as Field * rhs_minimum_index;
+
+        // if target_lt_smallest_entry, rhs_index = 0
+        // if target_gt_largest_entry, lhs_index = TranscriptEntries - 1
+        rhs_index = rhs_index * (1 - target_lt_smallest_entry as Field);
+
+        // we rely here on the fact that target_gt_largest_entry and result_not_first_or_last are mutually exclusive
+        lhs_index = lhs_index  + target_gt_largest_entry as Field * (N as Field - 1);
+
+        // If target is FOUND, we want the following:
+        // keyhash[target_index] - 1 < hash < keyhash[target_index] + 1
+        lhs_index = lhs_index  + found as Field * found_index;
+        rhs_index = rhs_index  + found as Field * found_index;
+
+        KeySearchResult { found, target_lt_smallest_entry, target_gt_largest_entry, lhs_index, rhs_index }
+    }
+
+    unconstrained fn __exists(self, idx: Field) -> bool {
+        let mut r: bool = false;
+        for i in 0..N {
+            if (self.keys[i] == idx) {
+                r = true;
+                break;
+            }
+        }
+        r
+    }
+
+    fn get(self, idx: Field) -> Field {
+        let search_result = unsafe {
+            self.search_for_key_in_map(idx)
+        };
+
+        let found = search_result.found as Field;
+
+        let target_lt_smallest_entry = search_result.target_lt_smallest_entry as Field;
+        let target_gt_largest_entry = search_result.target_gt_largest_entry as Field;
+
+        assert(((search_result.lhs_index - search_result.rhs_index) * found) == 0);
+
+        // only one of "found", "target_lt_smallest_entry", "target_gt_largest_entry" can be true
+        let exclusion_test = found + target_gt_largest_entry + target_lt_smallest_entry;
+        assert(exclusion_test * exclusion_test == exclusion_test);
+
+        let mut lhs = self.keys[search_result.lhs_index];
+        let mut rhs = self.keys[search_result.rhs_index];
+
+        // case where hash < self.key_hashes[0]
+        // 0 < hash < hashes[0]
+        lhs = lhs * (1 - target_lt_smallest_entry);
+
+        // case where hash > self.key_hashes[last]
+        // largest < x < -1
+        rhs = rhs * (1 - target_gt_largest_entry) + target_gt_largest_entry * 0x100000000;
+
+        // case where hash == self.key_hashes[found_index]
+        lhs = lhs - found;
+        rhs = rhs + found;
+
+        (idx - lhs - 1).assert_max_bit_size(32);
+        (rhs - idx - 1).assert_max_bit_size(32);
+
+        (self.maximum - idx - 1).assert_max_bit_size(32);
+
+        let value_index = search_result.lhs_index * found;
+
+        let value = self.values[value_index] * found;
+        value
+    }
+}
 /**
  * @brief Implements an elliptic curve instantiated over a prime field that is NOT the circuit's native field
  **/
-struct BigCurve<BigNum, CurveParams> {
+pub struct BigCurve<BigNum, CurveParams> {
     x: BigNum,
     y: BigNum,
     is_infinity: bool,
@@ -43,7 +186,7 @@ struct PointTable<BigNum> {
     y: [BigNum; 16],
 }
 
-impl<BigNum> PointTable<BigNum> where BigNum: BigNumTrait {
+impl<BigNum> PointTable<BigNum> where BigNum: BigNumTrait + std::ops::Add + std::ops::Mul + std::cmp::Eq {
     fn empty() -> Self {
         PointTable { x: [BigNum::new(); 16], y: [BigNum::new(); 16] }
     }
@@ -86,7 +229,24 @@ impl<BigNum> PointTable<BigNum> where BigNum: BigNumTrait {
     }
 }
 
-impl<BigNum, CurveParams> BigCurve<BigNum, CurveParams> where CurveParams: CurveParamsTrait<BigNum>, BigNum: BigNumTrait {
+trait BigCurveTrait {
+    fn neg(self) -> Self;
+    fn point_at_infinity() -> Self;
+    fn offset_generator() -> Self;
+    fn offset_generator_final() -> Self;
+    fn one() -> Self;
+    fn conditional_select(lhs: Self, rhs: Self, predicate: bool) -> Self;
+    fn validate_on_curve(self);
+    fn mul<let NScalarSlices: u32>(self, scalar: ScalarField<NScalarSlices>) -> Self;
+    fn hash_to_curve<let N: u32>(seed: [u8; N]) -> Self;
+}
+impl<BigNum, CurveParams> BigCurveTrait for BigCurve<BigNum, CurveParams> where CurveParams: CurveParamsTrait<BigNum>, BigNum: BigNumTrait + std::ops::Add + std::ops::Mul + std::cmp::Eq {
+
+    fn hash_to_curve<let N: u32>(seed: [u8; N]) -> Self {
+        let r = hash_to_curve::<BigNum, N>(seed, CurveParams::a(), CurveParams::b());
+        BigCurve { x: r.0, y: r.1, is_infinity: false }
+    }
+
     /**
     * @brief negate a point
     **/
@@ -140,6 +300,18 @@ impl<BigNum, CurveParams> BigCurve<BigNum, CurveParams> where CurveParams: Curve
             [false]
         );
     }
+
+    /// 64 * 5 = 320
+    // Expensive witness generation! Avoid if possible 
+    fn mul<let NScalarSlices: u32>(self, scalar: ScalarField<NScalarSlices>) -> Self {
+        let transcript: [AffineTranscript<BigNum>; (NScalarSlices * 5) + 6] = unsafe {
+            BigCurve::get_mul_transcript(self, scalar)
+        };
+
+        self.mul_with_hint(scalar, transcript)
+    }
+}
+impl<BigNum, CurveParams> BigCurve<BigNum, CurveParams> where CurveParams: CurveParamsTrait<BigNum>, BigNum: BigNumTrait + std::ops::Add + std::ops::Mul + std::cmp::Eq {
 
     /**
      * @brief Add two points together, using an AffineTranscript that contains inverses and output witnesses
@@ -454,6 +626,18 @@ impl<BigNum, CurveParams> BigCurve<BigNum, CurveParams> where CurveParams: Curve
         BigCurve { x: x3, y: y3, is_infinity: false }
     }
 
+    fn conditional_incomplete_add_with_hint(self, other: Self, predicate: bool, transcript: AffineTranscript<BigNum>) -> Self {
+        let operand_output = self.incomplete_add_with_hint(other, transcript);
+        let result = BigCurve::conditional_select(operand_output, self, predicate);
+        result
+    }
+
+    fn conditional_incomplete_subtract_with_hint(self, other: Self, predicate: bool, transcript: AffineTranscript<BigNum>) -> Self {
+        let operand_output = self.incomplete_subtract_with_hint(other, transcript);
+        let result = BigCurve::conditional_select(operand_output, self, predicate);
+        result
+    }
+
     /**
      * @brief Double a point, using an AffineTranscript that contains inverses and output witnesses
      * @note This method minimizes the number of calls to `evalute_quadratic_expression`,
@@ -541,9 +725,7 @@ impl<BigNum, CurveParams> BigCurve<BigNum, CurveParams> where CurveParams: Curve
 
         // windowed non-adjacent form can only represent odd scalar values.
         // if value is even, the result will be off by one and we need to subtract the input point
-        if (scalar.skew) {
-            accumulator = accumulator.incomplete_subtract_with_hint(input, transcript[4 + 5 * NScalarSlices]);
-        }
+        accumulator = accumulator.conditional_incomplete_subtract_with_hint(input, scalar.skew, transcript[4 + 5 * NScalarSlices]);
 
         accumulator = accumulator.sub_with_hint(BigCurve::offset_generator_final(), transcript[5 + 5 * NScalarSlices]);
         accumulator
@@ -611,9 +793,7 @@ impl<BigNum, CurveParams> BigCurve<BigNum, CurveParams> where CurveParams: Curve
         // windowed non-adjacent form can only represent odd scalar values.
         // if value is even, the result will be off by one and we need to subtract the input point
         for i in 0..Size {
-            if (scalars[i].skew) {
-                accumulator = accumulator.incomplete_subtract_with_hint(points[i], transcript[9 * Size + (4 + Size) * (NScalarSlices - 1) + i]);
-            }
+            accumulator = accumulator.conditional_incomplete_subtract_with_hint(points[i], scalars[i].skew, transcript[9 * Size + (4 + Size) * (NScalarSlices - 1) + i]);
         }
 
         accumulator
@@ -629,28 +809,28 @@ impl<BigNum, CurveParams> BigCurve<BigNum, CurveParams> where CurveParams: Curve
         accumulator
     }
 
-    unconstrained fn get_mul_transcript<let NScalarSlices: u32>(P: Self, scalar: ScalarField<NScalarSlices>) -> [AffineTranscript<BigNum>; 326] {
+    unconstrained fn get_mul_transcript<let NScalarSlices: u32>(
+        P: Self,
+        scalar: ScalarField<NScalarSlices>
+    ) -> [AffineTranscript<BigNum>; 6 + NScalarSlices * 5] {
         CurveJ::from(P).mul(scalar).1.as_array()
     }
 
-    // Expensive witness generation! Avoid if possible 
-    fn mul<let NScalarSlices: u32>(self, scalar: ScalarField<NScalarSlices>) -> Self {
-        let transcript: [AffineTranscript<BigNum>; 326] = unsafe {
-            BigCurve::get_mul_transcript(self, scalar)
-        };
-
-        self.mul_with_hint(scalar, transcript)
+    fn msm<let NScalarSlices: u32, let NMuls: u32>(
+        mul_points: [Self; NMuls],
+        mul_scalars: [ScalarField<NScalarSlices>; NMuls],
+    ) -> Self {
+        BigCurve::evaluate_linear_expression(mul_points, mul_scalars, [])
     }
 
     fn evaluate_linear_expression<let NScalarSlices: u32, let NMuls: u32, let NAdds: u32>(
-        mut mul_points: [Self; NMuls],
-        mut mul_scalars: [ScalarField<NScalarSlices>; NMuls],
+        mul_points: [Self; NMuls],
+        mul_scalars: [ScalarField<NScalarSlices>; NMuls],
         add_points: [Self; NAdds]
     ) -> Self {
-        let affine_transcript: AffineLinearExpressionTranscript<BigNum, NScalarSlices, NMuls, NAdds> = unsafe {
-            CurveJ::compute_linear_expression_transcript(mul_points, mul_scalars, add_points)
+        let transcript: [AffineTranscript<BigNum>; NScalarSlices * NMuls + NScalarSlices * 4 + NMuls * 9 + NAdds - 3] = unsafe {
+            CurveJ::compute_linear_expression_transcript(mul_points, mul_scalars, add_points).1
         };
-
         let mut _inputs: [Self; NMuls] = [BigCurve::one(); NMuls];
         let mut  _scalars: [ScalarField<NScalarSlices>; NMuls] = [ScalarField::new(); NMuls];
         for i in 0..NMuls {
@@ -662,32 +842,34 @@ impl<BigNum, CurveParams> BigCurve<BigNum, CurveParams> where CurveParams: Curve
 
         let mut tables: [PointTable<BigNum>; NMuls] = [PointTable::empty(); NMuls];
         for i in 0..NMuls {
-            tables[i] = PointTable::new_with_hint(msm_points[i], affine_transcript.table_transcript[i]);
+            let mut table_transcript: [AffineTranscript<BigNum>; 8] = [AffineTranscript::new(); 8];
+            for j in 0..8 {
+                table_transcript[j] = transcript[i * 8 + j];
+            }
+            tables[i] = PointTable::new_with_hint(msm_points[i], table_transcript);
         }
 
         // Init the accumulator from the most significant scalar slice
         let mut accumulator: Self = BigCurve::offset_generator();
         let mut accumulator = accumulator.incomplete_add_with_hint(
             tables[0].get(scalars[0].base4_slices[0]),
-            affine_transcript.msm_add_transcript[0][0]
+            transcript[8 * NMuls]
         );
-
         for i in 1..NMuls {
             accumulator = accumulator.incomplete_add_with_hint(
                 tables[i].get(scalars[i].base4_slices[0]),
-                affine_transcript.msm_add_transcript[0][i]
+                transcript[8 * NMuls + i]
             );
         }
 
         // Perform the "double and add" algorithm but in steps of 4 bits, using the lookup table T to extract 4-bit multiples of P
         for i in 1..NScalarSlices {
-            accumulator = accumulator.double_with_hint(affine_transcript.msm_double_transcript[i-1][0]);
-            accumulator = accumulator.double_with_hint(affine_transcript.msm_double_transcript[i-1][1]);
-            accumulator = accumulator.double_with_hint(affine_transcript.msm_double_transcript[i-1][2]);
-            accumulator = accumulator.double_with_hint(affine_transcript.msm_double_transcript[i-1][3]);
-
+            accumulator = accumulator.double_with_hint(transcript[9 * NMuls + (4 + NMuls) * (i - 1)]);
+            accumulator = accumulator.double_with_hint(transcript[9 * NMuls + (4 + NMuls) * (i - 1) + 1]);
+            accumulator = accumulator.double_with_hint(transcript[9 * NMuls + (4 + NMuls) * (i - 1) + 2]);
+            accumulator = accumulator.double_with_hint(transcript[9 * NMuls + (4 + NMuls) * (i - 1) + 3]);
             for j in 0..NMuls {
-                accumulator = accumulator.incomplete_add_with_hint(tables[j].get(scalars[j].base4_slices[i]), affine_transcript.msm_add_transcript[i][j]);
+                accumulator = accumulator.incomplete_add_with_hint(tables[j].get(scalars[j].base4_slices[i]), transcript[9 * NMuls + (4 + NMuls) * (i - 1) + 4 + j]);
             }
         }
 
@@ -696,23 +878,20 @@ impl<BigNum, CurveParams> BigCurve<BigNum, CurveParams> where CurveParams: Curve
         // windowed non-adjacent form can only represent odd scalar values.
         // if value is even, the result will be off by one and we need to subtract the input point
         for i in 0..NMuls {
-            if (scalars[i].skew) {
-                accumulator = accumulator.incomplete_subtract_with_hint(msm_points[i], affine_transcript.skew_transcript[i]);
-            }
+            accumulator = accumulator.conditional_incomplete_subtract_with_hint(msm_points[i], scalars[i].skew, transcript[9 * NMuls + (4 + NMuls) * (NScalarSlices - 1) + i]);
         }
 
         for i in 0..NAdds {
-            let res = accumulator.incomplete_subtract_with_hint(add_points[i], affine_transcript.add_transcript[i]);
-            accumulator = BigCurve::conditional_select(accumulator, res, add_points[i].is_infinity);
+            accumulator = accumulator.conditional_incomplete_add_with_hint(add_points[i], !add_points[i].is_infinity, transcript[10 * NMuls + (4 + NMuls) * (NScalarSlices - 1) + i]);
         }
 
-        accumulator = accumulator.sub_with_hint(BigCurve::offset_generator_final(), affine_transcript.offset_generator_transcript);
+        accumulator = accumulator.sub_with_hint(BigCurve::offset_generator_final(), transcript[NScalarSlices * NMuls + NScalarSlices * 4 + NMuls * 9 + NAdds - 4]);
 
         accumulator
     }
 }
 
-impl<BigNum, CurveParams> std::ops::Add for BigCurve<BigNum, CurveParams> where CurveParams: CurveParamsTrait<BigNum>, BigNum: BigNumTrait {
+impl<BigNum, CurveParams> std::ops::Add for BigCurve<BigNum, CurveParams> where CurveParams: CurveParamsTrait<BigNum>, BigNum: BigNumTrait + std::ops::Add + std::ops::Mul + std::cmp::Eq {
     // Expensive witness generation! Avoid if possible 
     fn add(self, other: Self) -> Self {
         let lhsJ = CurveJ::from(self);
@@ -726,7 +905,7 @@ impl<BigNum, CurveParams> std::ops::Add for BigCurve<BigNum, CurveParams> where 
     }
 }
 
-impl<BigNum, CurveParams> std::ops::Sub for BigCurve<BigNum, CurveParams> where CurveParams: CurveParamsTrait<BigNum>, BigNum: BigNumTrait {
+impl<BigNum, CurveParams> std::ops::Sub for BigCurve<BigNum, CurveParams> where CurveParams: CurveParamsTrait<BigNum>, BigNum: BigNumTrait + std::ops::Add + std::ops::Mul + std::cmp::Eq {
     // Expensive witness generation! Avoid if possible 
     fn sub(self, other: Self) -> Self {
         let lhsJ = CurveJ::from(self);
@@ -743,7 +922,7 @@ impl<BigNum, CurveParams> std::ops::Sub for BigCurve<BigNum, CurveParams> where 
 /**
  * @brief are two Affine points equal?
  **/
-impl<BigNum, CurveParams> std::cmp::Eq for BigCurve<BigNum, CurveParams> where BigNum: BigNumTrait {
+impl<BigNum, CurveParams> std::cmp::Eq for BigCurve<BigNum, CurveParams> where BigNum: BigNumTrait + std::ops::Add + std::ops::Mul + std::cmp::Eq {
     fn eq(self, other: Self) -> bool {
         let coords_equal = self.x.eq(other.x) & self.y.eq(other.y) & !self.is_infinity & !other.is_infinity;
         let infinity = self.is_infinity & other.is_infinity;

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -1,7 +1,5 @@
 use dep::bignum::BigNum;
 use dep::bignum::BigNumTrait;
-use dep::bignum::BigNumParamsTrait;
-use dep::bignum::runtime_bignum::BigNumParamsTrait as RuntimeBigNumParamsTrait;
 
 /**
  * @brief ScalarField represents a scalar multiplier as a sequence of 4-bit slices
@@ -16,7 +14,7 @@ use dep::bignum::runtime_bignum::BigNumParamsTrait as RuntimeBigNumParamsTrait;
  *          N.B. ScalarField bit values are not constrained to be smaller than the TE curve group order.
  *          ScalarField is used when performing scalar multiplications, where all operations wrap modulo the curve order
  **/
-struct ScalarField<let N: u32> {
+pub struct ScalarField<let N: u32> {
     base4_slices: [u8; N],
     skew: bool
 }
@@ -41,10 +39,11 @@ unconstrained fn get_wnaf_slices<let N: u32>(x: Field) -> ([u8; N], bool) {
     (result, skew)
 }
 
-unconstrained fn get_wnaf_slices2<let N: u32, let M: u32>(x: [Field; M]) -> ([u8; N], bool) {
+unconstrained fn get_wnaf_slices2<let N: u32, BigNum>(x: BigNum /*[Field; M]*/) -> ([u8; N], bool) where BigNum: BigNumTrait {
     let mut result: [u8; N] = [0; N];
-    let mut nibbles: [[u8; 30]; M] = [[0; 30]; M];
-    for i in 0..M {
+    let mut nibbles: [[u8; 30]; (N / 30) + 1] = [[0; 30]; (N / 30) + 1];
+    let x: [Field] = x.get();
+    for i in 0..x.len() {
         nibbles[i] = x[i].to_le_radix::<30>(16);
     }
 
@@ -66,27 +65,27 @@ unconstrained fn get_wnaf_slices2<let N: u32, let M: u32>(x: [Field; M]) -> ([u8
     (result, skew)
 }
 
-unconstrained fn get_modulus_slices() -> (Field, Field) {
-    let bytes = std::field::modulus_be_bytes();
-    let num_bytes = (std::field::modulus_num_bits() / 8) + ((std::field::modulus_num_bits() % 8 != 0) as u64);
-    let mut lo: Field = 0;
-    let mut hi: Field = 0;
-    for i in 0..(num_bytes / 2) {
-        hi *= 256;
-        hi += bytes[i] as Field;
-        lo *= 256;
-        lo += bytes[i + (num_bytes/2)] as Field;
-    }
-    if (num_bytes & 1 == 1) {
-        lo *= 256;
-        lo += bytes[num_bytes - 1] as Field;
-    }
-    (lo, hi)
-}
+// unconstrained fn get_modulus_slices() -> (Field, Field) {
+//     let bytes = std::field::modulus_be_bytes();
+//     let num_bytes = (std::field::modulus_num_bits() / 8) + ((std::field::modulus_num_bits() % 8 != 0) as u64);
+//     let mut lo: Field = 0;
+//     let mut hi: Field = 0;
+//     for i in 0..(num_bytes / 2) {
+//         hi *= 256;
+//         hi += bytes[i] as Field;
+//         lo *= 256;
+//         lo += bytes[i + (num_bytes/2)] as Field;
+//     }
+//     if (num_bytes & 1 == 1) {
+//         lo *= 256;
+//         lo += bytes[num_bytes - 1] as Field;
+//     }
+//     (lo, hi)
+// }
 
-unconstrained fn get_borrow_flag(lhs_lo: Field, rhs_lo: Field) -> bool {
-    lhs_lo.lt(rhs_lo + 1)
-}
+// unconstrained fn get_borrow_flag(lhs_lo: Field, rhs_lo: Field) -> bool {
+//     lhs_lo.lt(rhs_lo + 1)
+// }
 
 impl<let N: u32> std::convert::From<Field> for ScalarField<N> {
 
@@ -97,7 +96,9 @@ impl<let N: u32> std::convert::From<Field> for ScalarField<N> {
      **/
     fn from(x: Field) -> Self {
         let mut result: Self = ScalarField { base4_slices: [0; N], skew: false };
-        let (slices, skew): ([u8; N], bool) = unsafe{ get_wnaf_slices(x) };
+        let (slices, skew): ([u8; N], bool) = unsafe {
+            get_wnaf_slices(x)
+        };
         result.base4_slices = slices;
         result.skew = skew;
         if (N < 64) {
@@ -107,41 +108,42 @@ impl<let N: u32> std::convert::From<Field> for ScalarField<N> {
                 acc += (slices[i] as Field) * 2 - 15;
             }
             assert(acc - skew as Field == x);
-        }
-        else
-        {
-            // TODO: if num bits = 64, validate in sum of the bits is smaller than the Field modulus
-            let mut lo: Field = slices[(N/2)] as Field * 2 - 15;
-            let mut hi: Field = slices[0] as Field * 2 - 15;
-            let mut borrow_shift = 1;
-            for i in 1..(N/2) {
-                borrow_shift *= 16;
-                lo *= 16;
-                lo += (slices[(N/2) + i] as Field) * 2 - 15;
-                hi *= 16;
-                hi += (slices[i] as Field) * 2 - 15;
-            }
-            if ((N & 1) == 1)
-            {
-                borrow_shift *= 16;
-                lo *= 16;
-                lo += (slices[N-1] as Field) * 2 - 15;
-            }
-// 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593efffffff
-                                // 0x2833e84879b9709143e1f593f0000001
-                                // 0x8833e84879b9709143e1f593efffffff
-            lo -= skew as Field;
-            // Validate that the integer represented by (lo, hi) is smaller than the integer represented by (plo, phi)
-            let (plo, phi) = unsafe{ get_modulus_slices() };
-            let borrow = unsafe{ get_borrow_flag(plo, lo) as Field };
-            let rlo = plo - lo + borrow * borrow_shift - 1; // -1 because we are checking a strict <, not <=
-            let rhi = phi - hi - borrow;
-            let offset = (N & 1 == 1) as u32;
-            let hibits = (N / 2) * 4;
-            let lobits = hibits + offset * 4 + 1; // 1 extra bit to account for borrow
-            // 0x013833e84879b9709143e1f593f0000000
-            rlo.assert_max_bit_size(lobits as u32);
-            rhi.assert_max_bit_size(hibits as u32);
+        } else {
+            // TODO fix! this does not work because we are assuming N slices is smaller than 256 bits
+            // let mut lo: Field = slices[(N / 2)] as Field * 2 - 15;
+            // let mut hi: Field = slices[0] as Field * 2 - 15;
+            // let mut borrow_shift = 1;
+            // for i in 1..(N / 2) {
+            //     borrow_shift *= 16;
+            //     lo *= 16;
+            //     lo += (slices[(N/2) + i] as Field) * 2 - 15;
+            //     hi *= 16;
+            //     hi += (slices[i] as Field) * 2 - 15;
+            // }
+            // if ((N & 1) == 1) {
+            //     borrow_shift *= 16;
+            //     lo *= 16;
+            //     lo += (slices[N-1] as Field) * 2 - 15;
+            // }
+            // // 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593efffffff
+            // // 0x2833e84879b9709143e1f593f0000001
+            // // 0x8833e84879b9709143e1f593efffffff
+            // lo -= skew as Field;
+            // // Validate that the integer represented by (lo, hi) is smaller than the integer represented by (plo, phi)
+            // let (plo, phi) = unsafe {
+            //     get_modulus_slices()
+            // };
+            // let borrow = unsafe {
+            //     get_borrow_flag(plo, lo) as Field
+            // };
+            // let rlo = plo - lo + borrow * borrow_shift - 1; // -1 because we are checking a strict <, not <=
+            // let rhi = phi - hi - borrow;
+            // let offset = (N & 1 == 1) as u32;
+            // let hibits = (N / 2) * 4;
+            // let lobits = hibits + offset * 4 + 1; // 1 extra bit to account for borrow
+            // // 0x013833e84879b9709143e1f593f0000000
+            // // rlo.assert_max_bit_size(lobits as u32);
+            // // rhi.assert_max_bit_size(hibits as u32);
         }
         for i in 0..N {
             (result.base4_slices[i] as Field).assert_max_bit_size(4);
@@ -166,8 +168,20 @@ impl<let N: u32> std::convert::Into<Field> for ScalarField<N> {
     }
 }
 
-impl<let N: u32> ScalarField<N> {
+pub trait ScalarFieldTrait {
+    fn zero() -> Self;
+    fn conditional_select(lhs: Self, rhs: Self, predicate: bool) -> Self;
+    fn from_bignum<BigNum>(x: BigNum) -> Self where BigNum: BigNumTrait;
+    fn into_bignum<BigNum>(self) -> BigNum where BigNum: BigNumTrait;
+    fn new() -> Self;
+    fn get(self, idx: u64) -> u8;
+    fn len(self) -> u32;
+}
+impl<let N: u32> ScalarFieldTrait for ScalarField<N> {
 
+    fn len(_: Self) -> u32 {
+        N
+    }
     fn zero() -> Self {
         let mut result: Self = ScalarField { base4_slices: [0; N], skew: true };
 
@@ -184,10 +198,10 @@ impl<let N: u32> ScalarField<N> {
     }
 
     // Note: I can't propagate ModulusBits or NumLimbs from a generic that satisfies BigNumTrait due to bugs, so we have to pass NumLimbs and Params in directly. disgusting!
-    fn from_bignum<let NumLimbs: u32, Params>(x: BigNum<NumLimbs, Params>) -> Self where Params: BigNumParamsTrait<NumLimbs> + RuntimeBigNumParamsTrait<NumLimbs> {
+    fn from_bignum<BigNum>(x: BigNum) -> Self where BigNum: BigNumTrait {
         x.validate_in_field();
         let mut (slices, skew): ([u8; N], bool) = unsafe {
-            get_wnaf_slices2(x.limbs)
+            get_wnaf_slices2(x)
         };
 
         // TODO: NONE OF THIS IS CONSTRAINED YET. FIX!

--- a/src/test_data.nr
+++ b/src/test_data.nr
@@ -1,4 +1,4 @@
-use dep::bignum::fields::bn254Fq::BNParams as BNParams;
+use dep::bignum::fields::bn254Fq::BNParams;
 use dep::bignum::BigNum;
 use crate::curve_jac::AffineTranscript;
 

--- a/src/utils.nr
+++ b/src/utils.nr
@@ -1,0 +1,2 @@
+pub(crate) mod hash_to_curve;
+pub(crate) mod derive_offset_generators;

--- a/src/utils/derive_offset_generators.nr
+++ b/src/utils/derive_offset_generators.nr
@@ -1,0 +1,633 @@
+use dep::bignum::BigNumTrait;
+use crate::CurveParamsTrait;
+use crate::BigCurve;
+use crate::curve_jac::CurveJ;
+
+use dep::bignum::BigNum;
+use dep::bignum::fields::bls12_377Fq::BLS12_377_Fq_Params;
+use dep::bignum::fields::bls12_381Fq::BLS12_381_Fq_Params;
+use dep::bignum::fields::secp256k1Fq::Secp256k1_Fq_Params;
+use dep::bignum::fields::secp256r1Fq::Secp256r1_Fq_Params;
+use dep::bignum::fields::secp384r1Fq::Secp384r1_Fq_Params;
+use dep::bignum::fields::mnt4_753Fq::MNT4_753_Fq_Params;
+use dep::bignum::fields::mnt6_753Fq::MNT6_753_Fq_Params;
+use dep::bignum::fields::pallasFq::Pallas_Fq_Params;
+use dep::bignum::fields::vestaFq::Vesta_Fq_Params;
+use dep::bignum::fields::ed25519Fq::ED25519_Fq_Params;
+use dep::bignum::fields::bn254Fq::BNParams;
+type BLS377BN = BigNum<4, BLS12_377_Fq_Params>;
+type BLS381BN = BigNum<4, BLS12_381_Fq_Params>;
+type Secp256k1BN = BigNum<3, Secp256k1_Fq_Params>;
+type Secp256r1BN = BigNum<3, Secp256r1_Fq_Params>;
+type Secp384r1BN = BigNum<4, Secp384r1_Fq_Params>;
+type Mnt4BN = BigNum<7, MNT4_753_Fq_Params>;
+type Mnt6BN = BigNum<7, MNT6_753_Fq_Params>;
+type PallasBN = BigNum<3, Pallas_Fq_Params>;
+type VestaBN = BigNum<3, Vesta_Fq_Params>;
+type ED25519BN = BigNum<3, ED25519_Fq_Params>;
+type BN254 = BigNum<3, BNParams>;
+
+pub struct BLS377PartialCurveParams {
+
+}
+
+impl CurveParamsTrait<BLS377BN> for BLS377PartialCurveParams {
+    fn a() -> BLS377BN {
+        BigNum::new()
+    }
+    fn b() -> BLS377BN {
+        BigNum::one()
+    }
+    fn one() -> [BLS377BN; 2] {
+        let mut y: BLS377BN = BigNum {
+            limbs: [
+                0xfe3d3634a9591afd82de55559c8ea6,
+                0xb348ca3e52d96d182ad44fb82305c2,
+                0x69c5102eff1f674f5d30afeec4bd7f,
+                0x01914a
+            ]
+        };
+        let mut x: BLS377BN = BigNum {
+            limbs: [
+                0x481512ffcd394eeab9b16eb21be9ef,
+                0x1e2caa9d41bb188282c8bd37cb5cd5,
+                0xdefe740a67c8fc6225bf87ff548595,
+                0x008848
+            ]
+        };
+        [x, y]
+    }
+
+    fn offset_generator_final() -> [BLS377BN; 2] {
+        BLS377PartialCurveParams::one()
+    }
+
+    fn offset_generator() -> [BLS377BN; 2] {
+        BLS377PartialCurveParams::one()
+    }
+}
+
+pub struct BLS381PartialCurveParams {}
+impl CurveParamsTrait<BLS381BN> for BLS381PartialCurveParams {
+    fn a() -> BLS381BN {
+        BigNum::new()
+    }
+    fn b() -> BLS381BN {
+        let mut r = BigNum::new();
+        r.limbs[0] = 4;
+        r
+    }
+
+    fn one() -> [BLS381BN; 2] {
+        let mut y: BLS381BN = BigNum {
+            limbs: [
+                0x3CC744A2888AE40CAA232946C5E7E1,
+                0xE095D5D00AF600DB18CB2C04B3EDD0,
+                0x81E3AAA0F1A09E30ED741D8AE4FCF5,
+                0x08B3F4
+            ]
+        };
+        let mut x: BLS381BN = BigNum {
+            limbs: [
+                0x55E83FF97A1AEFFB3AF00ADB22C6BB,
+                0x8C4F9774B905A14E3A3F171BAC586C,
+                0xA73197D7942695638C4FA9AC0FC368,
+                0x17F1D3
+            ]
+        };
+        [x, y]
+    }
+
+    fn offset_generator_final() -> [BLS381BN; 2] {
+        assert(true == false, "generator does not exist!");
+        BLS381PartialCurveParams::one()
+    }
+
+    fn offset_generator() -> [BLS381BN; 2] {
+        assert(true == false, "generator does not exist!");
+        BLS381PartialCurveParams::one()
+    }
+}
+
+pub struct Curve25519PartialCurveParams {}
+impl CurveParamsTrait<ED25519BN> for Curve25519PartialCurveParams {
+    fn a() -> ED25519BN {
+        BigNum {
+            limbs: [
+                486662,
+                0,
+                0
+            ]
+        }
+    }
+    fn b() -> ED25519BN {
+        BigNum { limbs: [1, 0, 0] }
+    }
+
+    fn one() -> [ED25519BN; 2] {
+        let mut y: ED25519BN = BigNum {
+            limbs: [
+                0x3d4d7e6d7c61b229e9c5a27eced3d9,
+                0x19a1b8a086b4e01edd2c7748d14c92,
+                0x20ae
+            ]
+        };
+
+        let mut x: ED25519BN = BigNum {
+            limbs: [
+                9,
+                0,
+                0
+            ]
+        };
+        [x, y]
+    }
+
+    fn offset_generator_final() -> [ED25519BN; 2] {
+        assert(true == false, "generator does not exist!");
+        Curve25519PartialCurveParams::one()
+    }
+
+    fn offset_generator() -> [ED25519BN; 2] {
+        assert(true == false, "generator does not exist!");
+        Curve25519PartialCurveParams::one()
+    }
+}
+
+pub struct Secp256r1PartialCurveParams {}
+impl CurveParamsTrait<Secp256r1BN> for Secp256r1PartialCurveParams {
+    fn a() -> Secp256r1BN {
+        BigNum {
+            limbs: [
+                0x000000fffffffffffffffffffffffc,
+                0xffff00000001000000000000000000,
+                0xffff
+            ]
+        }
+    }
+    fn b() -> Secp256r1BN {
+        BigNum {
+            limbs: [
+                0x1d06b0cc53b0f63bce3c3e27d2604b,
+                0x35d8aa3a93e7b3ebbd55769886bc65,
+                0x5ac6
+            ]
+        }
+    }
+
+    fn one() -> [Secp256r1BN; 2] {
+        let mut y: Secp256r1BN = BigNum {
+            limbs: [
+                0xce33576b315ececbb6406837bf51f5,
+                0x42e2fe1a7f9b8ee7eb4a7c0f9e162b,
+                0x4fe3
+            ]
+        };
+        let mut x: Secp256r1BN = BigNum {
+            limbs: [
+                0x037d812deb33a0f4a13945d898c296,
+                0xd1f2e12c4247f8bce6e563a440f277,
+                0x6b17
+            ]
+        };
+        [x, y]
+    }
+
+    fn offset_generator_final() -> [Secp256r1BN; 2] {
+        assert(true == false, "generator does not exist!");
+        Secp256r1PartialCurveParams::one()
+    }
+
+    fn offset_generator() -> [Secp256r1BN; 2] {
+        assert(true == false, "generator does not exist!");
+        Secp256r1PartialCurveParams::one()
+    }
+}
+
+pub struct Secp384r1PartialCurveParams {}
+impl CurveParamsTrait<Secp384r1BN> for Secp384r1PartialCurveParams {
+    fn a() -> Secp384r1BN {
+        let x: Secp384r1BN = BigNum {
+            limbs: [
+                3,
+                0,
+                0,
+                0
+            ]
+        };
+        x.neg()
+    }
+    fn b() -> Secp384r1BN {
+        BigNum {
+            limbs: [
+                0x56398D8A2ED19D2A85C8EDD3EC2AEF,
+                0x9C6EFE8141120314088F5013875AC6,
+                0xA7E23EE7E4988E056BE3F82D19181D,
+                0xB3312F
+            ]
+        }
+    }
+
+    fn one() -> [Secp384r1BN; 2] {
+        let mut y: Secp384r1BN = BigNum {
+            limbs: [
+                0x60B1CE1D7E819D7A431D7C90EA0E5F,
+                0x1DBD289A147CE9DA3113B5F0B8C00A,
+                0x4A96262C6F5D9E98BF9292DC29F8F4,
+                0x3617DE
+            ]
+        };
+
+        let mut x: Secp384r1BN = BigNum {
+            limbs: [
+                0x02F25DBF55296C3A545E3872760AB7,
+                0x3B628BA79B9859F741E082542A3855,
+                0x22BE8B05378EB1C71EF320AD746E1D,
+                0xAA87CA
+            ]
+        };
+        [x, y]
+    }
+
+    fn offset_generator_final() -> [Secp384r1BN; 2] {
+        assert(true == false, "generator does not exist!");
+        Secp384r1PartialCurveParams::one()
+    }
+
+    fn offset_generator() -> [Secp384r1BN; 2] {
+        assert(true == false, "generator does not exist!");
+        Secp384r1PartialCurveParams::one()
+    }
+}
+
+pub struct Secp256k1PartialCurveParams {}
+impl CurveParamsTrait<Secp256k1BN> for Secp256k1PartialCurveParams {
+    fn a() -> Secp256k1BN {
+        BigNum {
+            limbs: [
+                0,
+                0,
+                0
+            ]
+        }
+    }
+    fn b() -> Secp256k1BN {
+        BigNum {
+            limbs: [
+                7,
+                0,
+                0
+            ]
+        }
+    }
+
+    fn one() -> [Secp256k1BN; 2] {
+        let mut y: Secp256k1BN = BigNum {
+            limbs: [
+                0x17b448a68554199c47d08ffb10d4b8,
+                0xda7726a3c4655da4fbfc0e1108a8fd,
+                0x483a
+            ]
+        };
+        let mut x: Secp256k1BN = BigNum {
+            limbs: [
+                0x9bfcdb2dce28d959f2815b16f81798,
+                0x667ef9dcbbac55a06295ce870b0702,
+                0x79be
+            ]
+        };
+        [x, y]
+    }
+
+    fn offset_generator_final() -> [Secp256k1BN; 2] {
+        assert(true == false, "generator does not exist!");
+        Secp256k1PartialCurveParams::one()
+    }
+
+    fn offset_generator() -> [Secp256k1BN; 2] {
+        assert(true == false, "generator does not exist!");
+        Secp256k1PartialCurveParams::one()
+    }
+}
+
+pub struct Mnt4PartialCurveParams {}
+impl CurveParamsTrait<Mnt4BN> for Mnt4PartialCurveParams {
+    fn a() -> Mnt4BN {
+        BigNum {
+            limbs: [
+                2,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0
+            ]
+        }
+    }
+    fn b() -> Mnt4BN {
+        BigNum {
+            limbs: [
+                0xAD265458E06372009C9A0491678EF4,
+                0x773111C36C8B1B4E8F1ECE940EF9EA,
+                0xC3D8BB21C8D68BB8CFB9DB4B8C8FBA,
+                0xA92C78DC537E51A16703EC9855C77F,
+                0x051C596560835DF0C9E50A5B59B882,
+                0xC9DCAE7A016AC5D7748D3313CD8E39,
+                0x01373684A8
+            ]
+        }
+    }
+
+    fn one() -> [Mnt4BN; 2] {
+        let mut y: Mnt4BN = BigNum {
+            limbs: [
+                0x031EA99CFF05E05EC3BE2E4A050358,
+                0x23036DB8FB990A342449CAEB92FA6B,
+                0x5DEA57EF53EE29157BDF1B741AEBD4,
+                0xEE5599DD7C3DFA4100284833115AEC,
+                0x7FDDCDEA19CB10B2BF61F37AE2C456,
+                0x26E257B175AE94DEB9E10ABA4BA72F,
+                0x4AB64735
+            ]
+        };
+
+        let mut x: Mnt4BN = BigNum {
+            limbs: [
+                0xC2AB23BE1C24740AF0FDEB3B7F1981,
+                0xFEFF338DD73A5A7EEECFBCE7CF95D3,
+                0x463D98A4EA009D57AAD9716F708885,
+                0x6D1EF781D1DE4FFB1F806B314C5AD3,
+                0xEFA5546444D40C82D6A271F1A43862,
+                0x450BB76A02D86DAAFFBAEB69995EB9,
+                0x542F1DAD
+            ]
+        };
+        [x, y]
+    }
+
+    fn offset_generator_final() -> [Mnt4BN; 2] {
+        assert(true == false, "generator does not exist!");
+        Mnt4PartialCurveParams::one()
+    }
+
+    fn offset_generator() -> [Mnt4BN; 2] {
+        assert(true == false, "generator does not exist!");
+        Mnt4PartialCurveParams::one()
+    }
+}
+
+pub struct Mnt6PartialCurveParams {}
+impl CurveParamsTrait<Mnt6BN> for Mnt6PartialCurveParams {
+    fn a() -> Mnt6BN {
+        BigNum {
+            limbs: [
+                11,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0
+            ]
+        }
+    }
+    fn b() -> Mnt6BN {
+        BigNum {
+            limbs: [
+                0xBA7505BA6FCF2485540B13DFC8468A,
+                0xF9A80A95F401867C4E80F4747FDE5A,
+                0x0FCF2C43D7BF847957C34CCA1E3585,
+                0xB7985993F62F03B22A9A3C737A1A1E,
+                0xBB64B2BB01B10E60A5D5DFE0A25714,
+                0x0863C79D56446237CE2E1468D14AE9,
+                0x7DA285E7
+            ]
+        }
+    }
+
+    fn one() -> [Mnt6BN; 2] {
+        let mut y: Mnt6BN = BigNum {
+            limbs: [
+                0x521DF9855687139F0C51754C0CCC49,
+                0x4D9992F5CBF4B2CC4C42EFF9A5A6C4,
+                0x0DC7A593CCE5A792E94D0020C335B7,
+                0x4C7A18ED9C4BD3C7ED0FFB31C57E61,
+                0x2A3585BDD6D7722C6C07D7873BB02D,
+                0x6E2EB3FCA70DC1063BAC3455180120,
+                0x128C02FFF
+            ]
+        };
+
+        let mut x: Mnt6BN = BigNum {
+            limbs: [
+                0x329A6FEFA9A1F3F7A1FBD93A7BFFB8,
+                0x1ACBF7DA60895B8B3D9D442C4C4123,
+                0xE5E3C57B6DF120CEE3CD9D867E66D1,
+                0x0C0D5FC5E818771B931F1D5BDD069C,
+                0x131C2437E884C4997FD1DCB409367D,
+                0x6E831147412CFB1002284F30338088,
+                0x255F8E87
+            ]
+        };
+        [x, y]
+    }
+
+    fn offset_generator_final() -> [Mnt6BN; 2] {
+        assert(true == false, "generator does not exist!");
+        Mnt6PartialCurveParams::one()
+    }
+
+    fn offset_generator() -> [Mnt6BN; 2] {
+        assert(true == false, "generator does not exist!");
+        Mnt6PartialCurveParams::one()
+    }
+}
+
+pub struct BN254PartialCurveParams {}
+impl CurveParamsTrait<BN254> for BN254PartialCurveParams {
+    fn a() -> BN254 {
+        BigNum { limbs: [0, 0, 0] }
+    }
+    fn b() -> BN254 {
+        BigNum { limbs: [3, 0, 0] }
+    }
+
+    fn one() -> [BN254; 2] {
+        let mut y: BN254 = BigNum { limbs: [2, 0, 0] };
+
+        let mut x: BN254 = BigNum::one();
+        [x, y]
+    }
+
+    fn offset_generator_final() -> [BN254; 2] {
+        assert(true == false, "generator does not exist!");
+        BN254PartialCurveParams::one()
+    }
+
+    fn offset_generator() -> [BN254; 2] {
+        assert(true == false, "generator does not exist!");
+        BN254PartialCurveParams::one()
+    }
+}
+
+pub struct PallasPartialCurveParams {}
+impl CurveParamsTrait<PallasBN> for PallasPartialCurveParams {
+    fn a() -> PallasBN {
+        BigNum { limbs: [0, 0, 0] }
+    }
+    fn b() -> PallasBN {
+        BigNum { limbs: [5, 0, 0] }
+    }
+
+    fn one() -> [PallasBN; 2] {
+        let mut y: PallasBN = BigNum { limbs: [2, 0, 0] };
+
+        let mut x: PallasBN = BigNum::one().neg();
+        [x, y]
+    }
+
+    fn offset_generator_final() -> [PallasBN; 2] {
+        assert(true == false, "generator does not exist!");
+        PallasPartialCurveParams::one()
+    }
+
+    fn offset_generator() -> [PallasBN; 2] {
+        assert(true == false, "generator does not exist!");
+        PallasPartialCurveParams::one()
+    }
+}
+
+pub struct VestaPartialCurveParams {}
+impl CurveParamsTrait<VestaBN> for VestaPartialCurveParams {
+    fn a() -> VestaBN {
+        BigNum { limbs: [0, 0, 0] }
+    }
+    fn b() -> VestaBN {
+        BigNum { limbs: [5, 0, 0] }
+    }
+
+    fn one() -> [VestaBN; 2] {
+        let mut y: VestaBN = BigNum { limbs: [2, 0, 0] };
+
+        let mut x: VestaBN = BigNum::one().neg();
+        [x, y]
+    }
+
+    fn offset_generator_final() -> [VestaBN; 2] {
+        assert(true == false, "generator does not exist!");
+        VestaPartialCurveParams::one()
+    }
+
+    fn offset_generator() -> [VestaBN; 2] {
+        assert(true == false, "generator does not exist!");
+        VestaPartialCurveParams::one()
+    }
+}
+/*
+(
+
+   )
+*/
+unconstrained fn compute_and_print_offset_generators<Fq, Curve, let K: u32, let J: u32, let NScalarSlices: u32>(
+    n: u32,
+    paramstr: str<K>,
+    curvestr: str<J>,
+    cofactor: Field
+) where Fq: BigNumTrait + std::ops::Mul + std::ops::Add + std::cmp::Eq, Curve:CurveParamsTrait<Fq> {
+    let a = Curve::a();
+    let b = Curve::b();
+    let one = Curve::one();
+
+    let input: BigCurve<Fq, Curve> = BigCurve::one();
+    input.validate_on_curve();
+
+    let seed: [u8; 25] = "bigcurve offset generator".as_bytes();
+
+    // we only need well-defined parameters for a and b, for hash_to_curve to work
+    // (no offset gneerators needed)
+    let g: BigCurve<Fq, Curve> = BigCurve::hash_to_curve(seed);
+
+    let g_init: CurveJ<Fq, Curve> = CurveJ { x: g.x, y: g.y, z: Fq::one(), is_infinity: false };
+    let mut gen = g_init;
+
+    let cofactor_bits: [u1; 128] = cofactor.to_be_bits();
+    let mut it: u32 = 0;
+    for i in 0..128 {
+        if (cofactor_bits[i] == 1) {
+            it = i+1;
+            break;
+        }
+    }
+
+    for i in it..128 {
+        gen = gen.dbl().0;
+        if (cofactor_bits[i] == 1) {
+            gen = gen.incomplete_add(g_init).0;
+        }
+    }
+
+    let mut offset_generator_initial: [Fq; 2] = [Fq::new(); 2];
+    let mut offset_generator_final: [Fq; 2] = [Fq::new(); 2];
+
+    {
+        let mut genz = gen.z;
+        genz = genz.__invmod();
+        let zz = genz.__mul(genz);
+        let zzz = zz.__mul(genz);
+
+        offset_generator_initial[0] = gen.x.__mul(zz);
+        offset_generator_initial[1] = gen.y.__mul(zzz);
+    }
+
+    let end = (NScalarSlices - 1) * 4;
+    for _ in 0..end {
+        gen = gen.dbl().0;
+    }
+    {
+        let mut genz = gen.z;
+        genz = genz.__invmod();
+        let zz = genz.__mul(genz);
+        let zzz = zz.__mul(genz);
+
+        offset_generator_final[0] = gen.x.__mul(zz);
+        offset_generator_final[1] = gen.y.__mul(zzz);
+    }
+
+    println(f"pub struct {curvestr} {}");
+    println(f"impl CurveParamsTrait<BigNum<{n}, {paramstr}>> for {curvestr} {");
+
+    println(f"  fn a() -> BigNum<{n}, {paramstr}> { {a} }");
+    println(f"  fn b() -> BigNum<{n}, {paramstr}> { {b} }");
+    println(f"  fn one() -> [BigNum<{n}, {paramstr}>; 2] { {one} }");
+    println(f"  fn offset_generator() -> [BigNum<{n}, {paramstr}>; 2] { {offset_generator_initial} }");
+    println(f"  fn offset_generator_final() -> [BigNum<{n}, {paramstr}>; 2] { {offset_generator_final} }");
+    println("}");
+}
+
+#[test]
+fn test_compute_and_print_offset_generators() {
+    unsafe {
+        compute_and_print_offset_generators::<BN254, BN254PartialCurveParams, _, _, 64>(3, "BN254_Fq_Params", "BN254PartialCurveParams", 1);
+        // compute_and_print_offset_generators::<PallasBN, PallasPartialCurveParams, _, _, 64>(3, "Pallas_Fq_Params", "Pallas_Params", 1);
+        // compute_and_print_offset_generators::<VestaBN, VestaPartialCurveParams, _, _, 64>(3, "Vesta_Fq_Params", "Vesta_Params", 1);
+        // compute_and_print_offset_generators::<BLS377BN, BLS377PartialCurveParams, _, _, 64>(
+        //     4,
+        //     "BLS12_377_Fq_Params",
+        //     "BLS12_377_Params",
+        //     0x170b5d44300000000000000000000000
+        // );
+        // compute_and_print_offset_generators::<BLS381BN, BLS381PartialCurveParams, _, _, 64>(
+        //     4,
+        //     "BLS12_381_Fq_Params",
+        //     "BLS12_381_Params",
+        //     0x396C8C005555E1568C00AAAB0000AAAB
+        // );
+        // compute_and_print_offset_generators::<Mnt4BN, Mnt4PartialCurveParams, _, _, 189>(7, "MNT4_753_Fq_Params", "MNT4_753_Params", 1);
+        // compute_and_print_offset_generators::<Mnt6BN, Mnt6PartialCurveParams, _, _, 189>(7, "MNT6_753_Fq_Params", "MNT6_753_Params", 1);
+        // compute_and_print_offset_generators::<Secp256k1BN, Secp256k1PartialCurveParams, _, _, 65>(3, "Secp256k1_Fq_Params", "Secp256k1_Params", 1);
+        // compute_and_print_offset_generators::<Secp256r1BN, Secp256r1PartialCurveParams, _, _, 65>(3, "Secp256r1_Fq_Params", "Secp256r1_Params", 1);
+        // compute_and_print_offset_generators::<Secp384r1BN, Secp384r1PartialCurveParams, _, _, 97>(4, "Secp384r1_Fq_Params", "Secp384r1_Params", 1);
+        // cofactor = 0x170b5d44300000000000000000000000 booooo 
+    }
+}

--- a/src/utils/hash_to_curve.nr
+++ b/src/utils/hash_to_curve.nr
@@ -1,0 +1,88 @@
+use dep::bignum::BigNumTrait;
+
+unconstrained fn hash_to_curve_inner<Fq, let SeedBytes: u32>(
+    seedbase: Field,
+    seed_counter: Field,
+    a: Fq,
+    b: Fq
+) -> (Fq, Fq, Field) where Fq:BigNumTrait + std::ops::Mul + std::ops::Add + std::cmp::Eq {
+    let seedhash = std::hash::poseidon2::Poseidon2::hash([seedbase, seed_counter], 2);
+    // TODO: assert in field?
+
+    let seedhash: [u8; 32] = seedhash.to_le_bytes();
+
+    let x = Fq::derive_from_seed(seedhash);
+
+    let yy = x * x * x + a * x + b;
+    yy.validate_in_field();
+    yy.validate_in_range();
+    x.validate_in_field();
+    x.validate_in_range();
+    let y = yy.__tonelli_shanks_sqrt();
+    let yy_reconstructed = y._value * y._value;
+    let mut result: (Fq, Fq, Field) = (x, y._value, seed_counter);
+    if (((yy_reconstructed == yy) & (y._is_some)) == false) {
+        result = hash_to_curve_inner(seedbase, seed_counter + 1, a, b);
+    }
+    if (y.is_some()) {
+        y._value.validate_in_field();
+        y._value.validate_in_range();
+    }
+    result
+}
+
+unconstrained fn __hash_to_curve_witgen<Fq, let SeedBytes: u32>(
+    seed: [u8; SeedBytes],
+    a: Fq,
+    b: Fq
+) -> (Fq, Fq, Field) where Fq:BigNumTrait + std::ops::Mul + std::ops::Add + std::cmp::Eq {
+    let hashed_seed = poseidon_hash_bytes(seed);
+    hash_to_curve_inner(hashed_seed, 0, a, b)
+}
+
+fn poseidon_hash_bytes<let SeedBytes: u32>(seed: [u8; SeedBytes]) -> Field {
+    let mut padded_seed: [u8; (SeedBytes / 31 + 1) * 31] = [0; (SeedBytes / 31 + 1) * 31];
+    for i in 0..SeedBytes {
+        padded_seed[i] = seed[i];
+    }
+    let packed_seed: [Field; SeedBytes / 31 + 1] = [0; SeedBytes / 31 + 1];
+    for i in 0..SeedBytes / 31 + 1 {
+        let mut packed: Field = 0;
+        for _ in 0..31 {
+            packed *= 256;
+            packed += padded_seed[i] as Field;
+        }
+    }
+    let hashed_seed: Field = std::hash::poseidon2::Poseidon2::hash(packed_seed, SeedBytes / 31 + 1);
+    hashed_seed
+}
+pub fn hash_to_curve<Fq, let SeedBytes: u32>(
+    seed: [u8; SeedBytes],
+    a: Fq,
+    b: Fq
+) -> (Fq, Fq) where Fq:BigNumTrait + std::ops::Mul + std::ops::Add + std::cmp::Eq {
+    let (_, y, salt) = unsafe {
+        __hash_to_curve_witgen(seed, a, b)
+    };
+    let outer_hash: Field = poseidon_hash_bytes(seed);
+
+    let inner_hash = std::hash::poseidon2::Poseidon2::hash([outer_hash, salt], 2);
+
+    // TODO do we need to assert is in field?; I think we do?
+    let inner_hash: [u8; 32] = inner_hash.to_le_bytes();
+    let x = Fq::derive_from_seed(inner_hash);
+    let yy = x * x * x + a * x + b;
+    assert(y * y == yy);
+
+    let parity_flag = (inner_hash[0] & 1) == 1;
+
+    let negated_y = y.neg();
+    let output_y = Fq::conditional_select(y, negated_y, parity_flag);
+
+    x.validate_in_field();
+    x.validate_in_range();
+    output_y.validate_in_field();
+    output_y.validate_in_range();
+    (x, output_y)
+}
+


### PR DESCRIPTION
# Description

added fully constrained `hash_to_curve` method

fixed bug where `evaluate_linear_expression` was not working

added `msm` method into `BigCurve`

## Problem\*

Previously BigCurve did not provide parameters for predefined cures, requiring the user to derive them (including offset generators)

## Summary\*


This PR now adds a `hash_to_curve` method that is used to create methods that derive offset generators and curve parameters directly in Noir.

In addition, predefined parameters for the following curves are defined in the `curves` directory:

* BN254
* BLS12-377
* BLS12-381
* Secp256k1
* Secp256r1
* Secp384r1
* MNT4-753
* MNT6-753
* Pasta
* Vesta


## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
