### PR TITLE
chore: bump `noir_sort` to `v0.2.1`

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -6,4 +6,4 @@ compiler_version = ">=0.37.0"
 
 [dependencies]
 bignum = {tag = "v0.4.2", git = "https://github.com/noir-lang/noir-bignum"}
-sort = {tag = "v0.2.0", git = "https://github.com/noir-lang/noir_sort"}
+sort = {tag = "v0.2.1", git = "https://github.com/noir-lang/noir_sort"}


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This pulls a version of `noir_sort` which addresses the visibility warnings.

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
