### PR TITLE
chore: bump bignum version to `v0.5.4`

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,5 +5,5 @@ authors = [""]
 compiler_version = ">=1.0.0"
 
 [dependencies]
-bignum = {tag = "v0.5.3", git = "https://github.com/noir-lang/noir-bignum"}
+bignum = {tag = "v0.5.4", git = "https://github.com/noir-lang/noir-bignum"}
 sort = {tag = "v0.2.2", git = "https://github.com/noir-lang/noir_sort"}

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,5 +5,5 @@ authors = [""]
 compiler_version = ">=1.0.0"
 
 [dependencies]
-bignum = {tag = "v0.5.0", git = "https://github.com/noir-lang/noir-bignum"}
+bignum = {tag = "v0.5.2", git = "https://github.com/noir-lang/noir-bignum"}
 sort = {tag = "v0.2.2", git = "https://github.com/noir-lang/noir_sort"}

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,5 +5,5 @@ authors = [""]
 compiler_version = ">=1.0.0"
 
 [dependencies]
-bignum = {tag = "v0.5.2", git = "https://github.com/noir-lang/noir-bignum"}
+bignum = {tag = "v0.5.3", git = "https://github.com/noir-lang/noir-bignum"}
 sort = {tag = "v0.2.2", git = "https://github.com/noir-lang/noir_sort"}


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
