### PR TITLE
chore: bump poseidon to 0.1.1

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,5 +5,5 @@ authors = [""]
 compiler_version = ">=1.0.0"
 
 [dependencies]
-bignum = {tag = "v0.7.3", git = "https://github.com/noir-lang/noir-bignum"}
-poseidon = { git = "https://github.com/noir-lang/poseidon", tag = "v0.1.0" }
+bignum = { tag = "v0.7.3", git = "https://github.com/noir-lang/noir-bignum" }
+poseidon = { git = "https://github.com/noir-lang/poseidon", tag = "v0.1.1" }


### PR DESCRIPTION
# Description

## Problem

For https://github.com/noir-lang/noir/pull/7908

## Summary



## Additional Context



# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
