### PR TITLE
feat: use to_le_bytes and bitwise operations to replace to_le_radix

### DIFF
--- a/src/curves/bls12_377.nr
+++ b/src/curves/bls12_377.nr
@@ -125,4 +125,11 @@ mod test {
         );
     }
 
+    #[test]
+    unconstrained fn test_scalar_field_conversion(seed: [u8; 10]) {
+        let num: BLS12_377_Fr = BLS12_377_Fr::derive_from_seed(seed);
+        let scalar_field = BLS12_377Scalar::from_bignum(num);
+        let bignum = scalar_field.into_bignum();
+        assert(bignum == num);
+    }
 }

--- a/src/curves/bls12_381.nr
+++ b/src/curves/bls12_381.nr
@@ -122,4 +122,12 @@ mod test {
         );
     }
 
+    #[test]
+    unconstrained fn test_scalar_field_conversion(seed: [u8; 10]) {
+        let num: BLS12_381_Fr = BLS12_381_Fr::derive_from_seed(seed);
+        let scalar_field = BLS12_381Scalar::from_bignum(num);
+        let bignum = scalar_field.into_bignum();
+        assert(bignum == num);
+    }
+
 }

--- a/src/curves/bn254.nr
+++ b/src/curves/bn254.nr
@@ -101,4 +101,12 @@ mod test {
         // BN254 cofactor is 1
         crate::utils::derive_offset_generators::verify_offset_generators::<BN254_Fq, BN254>(1);
     }
+
+    #[test]
+    unconstrained fn test_scalar_field_conversion(seed: [u8; 10]) {
+        let num: BN254_Fq = BN254_Fq::derive_from_seed(seed);
+        let scalar_field = BN254Scalar::from_bignum(num);
+        let bignum = scalar_field.into_bignum();
+        assert(bignum == num);
+    }
 }

--- a/src/curves/mnt4_753.nr
+++ b/src/curves/mnt4_753.nr
@@ -148,10 +148,10 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_scalar_field_conversion(num: MNT4_753_Fr) {
-        let scalar_field = MNT4_753Scalar::from_bignum(num);
-        let bignum = scalar_field.into_bignum();
-        assert(bignum == num);
-    }
+    // #[test]
+    // fn test_scalar_field_conversion(num: MNT4_753_Fr) {
+    //   let scalar_field = MNT4_753Scalar::from_bignum(num);
+    //    let bignum = scalar_field.into_bignum();
+    //    assert(bignum == num);
+    //}
 }

--- a/src/curves/mnt4_753.nr
+++ b/src/curves/mnt4_753.nr
@@ -148,10 +148,11 @@ mod test {
         );
     }
 
-    // #[test]
-    // fn test_scalar_field_conversion(num: MNT4_753_Fr) {
-    //   let scalar_field = MNT4_753Scalar::from_bignum(num);
-    //    let bignum = scalar_field.into_bignum();
-    //    assert(bignum == num);
-    //}
+    #[test]
+    unconstrained fn test_scalar_field_conversion(seed: [u8; 10]) {
+        let num: MNT4_753_Fr = MNT4_753_Fr::derive_from_seed(seed);
+        let scalar_field = MNT4_753Scalar::from_bignum(num);
+        let bignum = scalar_field.into_bignum();
+        assert(bignum == num);
+    }
 }

--- a/src/curves/mnt4_753.nr
+++ b/src/curves/mnt4_753.nr
@@ -147,4 +147,11 @@ mod test {
             1,
         );
     }
+
+    #[test]
+    fn test_scalar_field_conversion(num: MNT4_753_Fr) {
+        let scalar_field = MNT4_753Scalar::from_bignum(num);
+        let bignum = scalar_field.into_bignum();
+        assert(bignum == num);
+    }
 }

--- a/src/curves/mnt6_753.nr
+++ b/src/curves/mnt6_753.nr
@@ -147,4 +147,12 @@ mod test {
         );
     }
 
+    #[test]
+    unconstrained fn test_scalar_field_conversion(seed: [u8; 10]) {
+        let num: MNT6_753_Fr = MNT6_753_Fr::derive_from_seed(seed);
+        let scalar_field = MNT6_753Scalar::from_bignum(num);
+        let bignum = scalar_field.into_bignum();
+        assert(bignum == num);
+    }
+
 }

--- a/src/curves/pallas.nr
+++ b/src/curves/pallas.nr
@@ -106,4 +106,12 @@ mod test {
         crate::utils::derive_offset_generators::verify_offset_generators::<Pallas_Fq, Pallas>(1);
     }
 
+    #[test]
+    unconstrained fn test_scalar_field_conversion(seed: [u8; 10]) {
+        let num: Pallas_Fr = Pallas_Fr::derive_from_seed(seed);
+        let scalar_field = PallasScalar::from_bignum(num);
+        let bignum = scalar_field.into_bignum();
+        assert(bignum == num);
+    }
+
 }

--- a/src/curves/secp256k1.nr
+++ b/src/curves/secp256k1.nr
@@ -116,4 +116,12 @@ mod test {
             1,
         );
     }
+
+    #[test(should_fail)]
+    unconstrained fn test_scalar_field_conversion(seed: [u8; 10]) {
+        let num: Secp256k1_Fr = Secp256k1_Fr::derive_from_seed(seed);
+        let scalar_field = Secp256k1Scalar::from_bignum(num);
+        let bignum = scalar_field.into_bignum();
+        assert(bignum == num);
+    }
 }

--- a/src/curves/secp256k1.nr
+++ b/src/curves/secp256k1.nr
@@ -117,7 +117,7 @@ mod test {
         );
     }
 
-    #[test(should_fail)]
+    #[test]
     unconstrained fn test_scalar_field_conversion(seed: [u8; 10]) {
         let num: Secp256k1_Fr = Secp256k1_Fr::derive_from_seed(seed);
         let scalar_field = Secp256k1Scalar::from_bignum(num);

--- a/src/curves/secp256r1.nr
+++ b/src/curves/secp256r1.nr
@@ -125,4 +125,12 @@ mod test {
         );
     }
 
+    #[test(should_fail)]
+    unconstrained fn test_scalar_field_conversion(seed: [u8; 10]) {
+        let num: Secp256r1_Fr = Secp256r1_Fr::derive_from_seed(seed);
+        let scalar_field = Secp256r1Scalar::from_bignum(num);
+        let bignum = scalar_field.into_bignum();
+        assert(bignum == num);
+    }
+
 }

--- a/src/curves/secp256r1.nr
+++ b/src/curves/secp256r1.nr
@@ -125,7 +125,7 @@ mod test {
         );
     }
 
-    #[test(should_fail)]
+    #[test]
     unconstrained fn test_scalar_field_conversion(seed: [u8; 10]) {
         let num: Secp256r1_Fr = Secp256r1_Fr::derive_from_seed(seed);
         let scalar_field = Secp256r1Scalar::from_bignum(num);

--- a/src/curves/secp384r1.nr
+++ b/src/curves/secp384r1.nr
@@ -133,4 +133,11 @@ mod test {
         );
     }
 
+    #[test(should_fail)]
+    unconstrained fn test_scalar_field_conversion(seed: [u8; 10]) {
+        let num: Secp384r1_Fr = Secp384r1_Fr::derive_from_seed(seed);
+        let scalar_field = Secp384r1Scalar::from_bignum(num);
+        let bignum = scalar_field.into_bignum();
+        assert(bignum == num);
+    }
 }

--- a/src/curves/secp384r1.nr
+++ b/src/curves/secp384r1.nr
@@ -133,7 +133,7 @@ mod test {
         );
     }
 
-    #[test(should_fail)]
+    #[test]
     unconstrained fn test_scalar_field_conversion(seed: [u8; 10]) {
         let num: Secp384r1_Fr = Secp384r1_Fr::derive_from_seed(seed);
         let scalar_field = Secp384r1Scalar::from_bignum(num);

--- a/src/curves/vesta.nr
+++ b/src/curves/vesta.nr
@@ -103,4 +103,12 @@ mod test {
         // Vesta cofactor is 1
         crate::utils::derive_offset_generators::verify_offset_generators::<Vesta_Fq, Vesta>(1);
     }
+
+    #[test]
+    unconstrained fn test_scalar_field_conversion(seed: [u8; 10]) {
+        let num: Vesta_Fr = Vesta_Fr::derive_from_seed(seed);
+        let scalar_field = VestaScalar::from_bignum(num);
+        let bignum = scalar_field.into_bignum();
+        assert(bignum == num);
+    }
 }

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -203,7 +203,39 @@ impl<let N: u32> ScalarField<N> {
     {
         x.validate_in_field();
         let mut (slices, skew): ([u8; N], bool) = unsafe { get_wnaf_slices2(x) };
-        // TODO: NONE OF THIS IS CONSTRAINED YET. FIX!
+        for i in 0..N {
+            (slices[i] as Field).assert_max_bit_size::<4>();
+        }
+        let mut result = B::zero();
+        let mut count: u32 = 0;
+        {
+            let mut acc: u128 = 0;
+            let mut last_bits = (result.modulus_bits() % 120) as u64;
+            if (last_bits == 0) {
+                last_bits = 120;
+            }
+            let mut last_nibbles = (last_bits / 4) + (last_bits % 4 != 0) as u64;
+            for _ in 0..last_nibbles {
+                acc = acc * 16;
+                acc = acc + (slices[count] as u128) * 2 - 15;
+                count = count + 1;
+            }
+            result.set_limb(result.num_limbs() - 1, acc);
+        }
+        for i in 1..result.num_limbs() {
+            // Using a Field type to allow for negative numbers.
+            let mut acc: Field = 0;
+            for _ in 0..30 {
+                acc = acc * 16;
+                acc = acc + (slices[count] as Field) * 2 - 15;
+                count = count + 1;
+            }
+            // Handle overflow using helper function
+            let acc_u128 = handle_overflow::<B>(acc, &mut result, i);
+            result.set_limb(result.num_limbs() - 1 - i, acc_u128);
+        }
+        result.set_limb(0, result.get_limb(0) - skew as u128);
+        assert(result == x);
         Self { base4_slices: slices, skew }
     }
 
@@ -235,21 +267,8 @@ impl<let N: u32> ScalarField<N> {
                 acc = acc + (self.base4_slices[count] as Field) * 2 - 15;
                 count = count + 1;
             }
-            let mut acc_u128: u128 = acc as u128;
-            // Handle negative numbers. If the number is negative, it is greater than 2^120 in Field.
-            // All positive numbers are less than 2^120 in Field.
-            // For example, 42 is -6 + 3 * 2^4 with wnaf algorithm, but it should be 42 = 10 + 2 * 2^4
-            // To get the actual number 10, we need to subtract the number 6 from 2^4.
-            if acc_u128 >= 0x1000000000000000000000000000000 {
-                // find the actual number needed to be subtracted.
-                let reverse = (acc * -1) as u128;
-                acc_u128 = (1 as u128 << 120) - reverse;
-                acc = acc - 0x1000000000000000000000000000000;
-                result.set_limb(
-                    result.num_limbs() - i,
-                    result.get_limb((result.num_limbs() - i)) - 1,
-                );
-            }
+            // Handle overflow using helper function
+            let acc_u128 = handle_overflow::<B>(acc, &mut result, i);
             result.set_limb(result.num_limbs() - 1 - i, acc_u128);
         }
         result.set_limb(0, result.get_limb(0) - self.skew as u128);
@@ -288,6 +307,26 @@ pub(crate) unconstrained fn extract_nibbles_from_bytes<let N: u32, let M: u32>(
     }
 
     result
+}
+
+// Helper function to handle overflow in wNAF reconstruction
+fn handle_overflow<B: BigNum>(acc: Field, result: &mut B, limb_index: u32) -> u128 {
+    let mut acc_u128: u128 = acc as u128;
+
+    // Handle negative numbers. If the number is negative, it is greater than 2^120 in Field.
+    // All positive numbers are less than 2^120 in Field.
+    // For example, 42 is -6 + 3 * 2^4 with wnaf algorithm, but it should be 42 = 10 + 2 * 2^4
+    // To get the actual number 10, we need to subtract the number 6 from 2^4.
+    if acc_u128 >= 0x1000000000000000000000000000000 {
+        // find the actual number needed to be subtracted.
+        let reverse = (acc * -1) as u128;
+        acc_u128 = (1 as u128 << 120) - reverse;
+        result.set_limb(
+            result.num_limbs() - limb_index,
+            result.get_limb(result.num_limbs() - limb_index) - 1,
+        );
+    }
+    acc_u128
 }
 
 mod tests {

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -233,6 +233,7 @@ impl<let N: u32> ScalarField<N> {
             let mut acc: u128 = 0;
             for _ in 0..30 {
                 acc = acc * 16;
+                // TODO: this is not correct. Error: attempt to subtract with overflow
                 acc = acc + (self.base4_slices[count] as u128) * 2 - 15;
                 count = count + 1;
             }
@@ -281,4 +282,16 @@ pub(crate) unconstrained fn extract_nibbles_from_bytes<let N: u32, let M: u32>(
     }
 
     result
+}
+
+mod tests {
+    /**
+    use crate::scalar_field::ScalarField;
+    #[test]
+    unconstrained fn fuzz_test_scalar_field_conversion(f: Field) {
+        let scalar_field: ScalarField<64> = ScalarField::from(f);
+        let scalar_field2 = scalar_field.into();
+        assert(f == scalar_field2);
+    }
+    **/
 }

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -285,11 +285,11 @@ pub(crate) unconstrained fn extract_nibbles_from_bytes<let N: u32, let M: u32>(
 }
 
 mod tests {
-    // use crate::scalar_field::ScalarField;
-    // #[test]
-    // unconstrained fn fuzz_test_scalar_field_conversion(f: Field) {
-    //     let scalar_field: ScalarField<64> = ScalarField::from(f);
-    //     let scalar_field2 = scalar_field.into();
-    //     assert(f == scalar_field2);
-    // }
+    use crate::scalar_field::ScalarField;
+    #[test]
+    unconstrained fn fuzz_test_scalar_field_conversion(f: Field) {
+        let scalar_field: ScalarField<64> = ScalarField::from(f);
+        let scalar_field2 = scalar_field.into();
+        assert(f == scalar_field2);
+    }
 }

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -214,7 +214,7 @@ impl<let N: u32> ScalarField<N> {
             if (last_bits == 0) {
                 last_bits = 120;
             }
-            let mut last_nibbles = (last_bits / 4) + (last_bits % 4 != 0) as u64;
+            let mut last_nibbles = (last_bits / 4) + 1 as u64;
             for _ in 0..last_nibbles {
                 acc = acc * 16;
                 acc = acc + (slices[count] as u128) * 2 - 15;
@@ -251,7 +251,7 @@ impl<let N: u32> ScalarField<N> {
             if (last_bits == 0) {
                 last_bits = 120;
             }
-            let mut last_nibbles = (last_bits / 4) + (last_bits % 4 != 0) as u64;
+            let mut last_nibbles = (last_bits / 4) + 1 as u64;
             for _ in 0..last_nibbles {
                 acc = acc * 16;
                 acc = acc + (self.base4_slices[count] as u128) * 2 - 15;

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -26,8 +26,8 @@ pub struct ScalarField<let N: u32> {
 // 1, 2, 3, 4
 unconstrained fn get_wnaf_slices<let N: u32>(x: Field) -> ([u8; N], bool) {
     let mut result: [u8; N] = [0; N];
-    let bytes = x.to_le_bytes::<N/2>();
-    
+    let bytes = x.to_le_bytes::<N / 2>();
+
     // Extract nibbles from bytes
     let mut nibbles: [u8; N] = [0; N];
     nibbles = extract_nibbles_from_bytes(bytes);
@@ -35,7 +35,7 @@ unconstrained fn get_wnaf_slices<let N: u32>(x: Field) -> ([u8; N], bool) {
     let skew: bool = nibbles[0] & 1 == 0;
     nibbles[0] = nibbles[0] + (skew as u8);
     result[N - 1] = (nibbles[0] + 15) / 2;
-    
+
     for i in 1..N {
         let mut nibble: u8 = nibbles[i];
         result[N - 1 - i] = (nibble + 15) / 2;
@@ -261,7 +261,7 @@ impl<let N: u32> ScalarField<N> {
 unconstrained fn extract_nibbles_from_bytes<let N: u32>(bytes: [u8]) -> [u8; N] {
     let mut result: [u8; N] = [0; N];
     let mut nibble_idx = 0;
-    
+
     for i in 0..bytes.len() {
         if nibble_idx >= N {
             break;
@@ -277,6 +277,6 @@ unconstrained fn extract_nibbles_from_bytes<let N: u32>(bytes: [u8]) -> [u8; N] 
         result[nibble_idx] = (bytes[i] >> 4) & 0x0F;
         nibble_idx += 1;
     }
-    
+
     result
 }

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -26,7 +26,7 @@ pub struct ScalarField<let N: u32> {
 // 1, 2, 3, 4
 unconstrained fn get_wnaf_slices<let N: u32>(x: Field) -> ([u8; N], bool) {
     let mut result: [u8; N] = [0; N];
-    let bytes = x.to_le_bytes::<N / 2>();
+    let bytes = x.to_le_bytes::<32>();
 
     // Extract nibbles from bytes
     let mut nibbles: [u8; N] = [0; N];
@@ -56,7 +56,7 @@ where
     let mut nibbles: [[u8; 30]; (N / 30) + 1] = [[0; 30]; (N / 30) + 1];
     let x: [u128] = x.get_limbs().as_slice();
     for i in 0..x.len() {
-        let bytes = (x[i] as Field).to_le_bytes::<15>();
+        let bytes = (x[i] as Field).to_le_bytes::<30>();
         nibbles[i] = extract_nibbles_from_bytes(bytes);
     }
 
@@ -258,11 +258,13 @@ impl<let N: u32> ScalarField<N> {
     }
 }
 
-unconstrained fn extract_nibbles_from_bytes<let N: u32>(bytes: [u8]) -> [u8; N] {
+pub(crate) unconstrained fn extract_nibbles_from_bytes<let N: u32, let M: u32>(
+    bytes: [u8; M],
+) -> [u8; N] {
     let mut result: [u8; N] = [0; N];
     let mut nibble_idx = 0;
 
-    for i in 0..bytes.len() {
+    for i in 0..M {
         if nibble_idx >= N {
             break;
         }
@@ -274,7 +276,7 @@ unconstrained fn extract_nibbles_from_bytes<let N: u32>(bytes: [u8]) -> [u8; N] 
             break;
         }
         // Extract high nibble (bits 4-7)
-        result[nibble_idx] = (bytes[i] >> 4) & 0x0F;
+        result[nibble_idx] = (bytes[i] >> 4);
         nibble_idx += 1;
     }
 

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -26,11 +26,16 @@ pub struct ScalarField<let N: u32> {
 // 1, 2, 3, 4
 unconstrained fn get_wnaf_slices<let N: u32>(x: Field) -> ([u8; N], bool) {
     let mut result: [u8; N] = [0; N];
-    let mut nibbles = x.to_le_radix::<N>(16);
+    let bytes = x.to_le_bytes();
+    
+    // Extract nibbles from bytes using helper function
+    let mut nibbles: [u8; N] = [0; N];
+    nibbles = extract_nibbles_from_bytes(bytes);
 
     let skew: bool = nibbles[0] & 1 == 0;
-    nibbles[0] = nibbles[0] as u8 + (skew as u8);
+    nibbles[0] = nibbles[0] + (skew as u8);
     result[N - 1] = (nibbles[0] + 15) / 2;
+    
     for i in 1..N {
         let mut nibble: u8 = nibbles[i];
         result[N - 1 - i] = (nibble + 15) / 2;
@@ -51,11 +56,12 @@ where
     let mut nibbles: [[u8; 30]; (N / 30) + 1] = [[0; 30]; (N / 30) + 1];
     let x: [u128] = x.get_limbs().as_slice();
     for i in 0..x.len() {
-        nibbles[i] = (x[i] as Field).to_le_radix::<30>(16);
+        let bytes = (x[i] as Field).to_le_bytes();
+        nibbles[i] = extract_nibbles_from_bytes(bytes);
     }
 
     let skew: bool = nibbles[0][0] & 1 == 0;
-    nibbles[0][0] = nibbles[0][0] as u8 + (skew as u8);
+    nibbles[0][0] = nibbles[0][0] + (skew as u8);
     result[N - 1] = (nibbles[0][0] + 15) / 2;
 
     for i in 1..N {
@@ -250,4 +256,27 @@ impl<let N: u32> ScalarField<N> {
     pub fn get(self, idx: u32) -> u8 {
         self.base4_slices[idx]
     }
+}
+
+unconstrained fn extract_nibbles_from_bytes<let N: u32>(bytes: [u8]) -> [u8; N] {
+    let mut result: [u8; N] = [0; N];
+    let mut nibble_idx = 0;
+    
+    for i in 0..bytes.len() {
+        if nibble_idx >= N {
+            break;
+        }
+        // Extract high nibble (bits 4-7)
+        result[nibble_idx] = (bytes[i] >> 4) & 0x0F;
+        nibble_idx += 1;
+        
+        if nibble_idx >= N {
+            break;
+        }
+        // Extract low nibble (bits 0-3)
+        result[nibble_idx] = bytes[i] & 0x0F;
+        nibble_idx += 1;
+    }
+    
+    result
 }

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -285,13 +285,11 @@ pub(crate) unconstrained fn extract_nibbles_from_bytes<let N: u32, let M: u32>(
 }
 
 mod tests {
-    /**
-    use crate::scalar_field::ScalarField;
-    #[test]
-    unconstrained fn fuzz_test_scalar_field_conversion(f: Field) {
-        let scalar_field: ScalarField<64> = ScalarField::from(f);
-        let scalar_field2 = scalar_field.into();
-        assert(f == scalar_field2);
-    }
-    **/
+// use crate::scalar_field::ScalarField;
+// #[test]
+// unconstrained fn fuzz_test_scalar_field_conversion(f: Field) {
+//     let scalar_field: ScalarField<64> = ScalarField::from(f);
+//     let scalar_field2 = scalar_field.into();
+//     assert(f == scalar_field2);
+// }
 }

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -285,11 +285,11 @@ pub(crate) unconstrained fn extract_nibbles_from_bytes<let N: u32, let M: u32>(
 }
 
 mod tests {
-// use crate::scalar_field::ScalarField;
-// #[test]
-// unconstrained fn fuzz_test_scalar_field_conversion(f: Field) {
-//     let scalar_field: ScalarField<64> = ScalarField::from(f);
-//     let scalar_field2 = scalar_field.into();
-//     assert(f == scalar_field2);
-// }
+    // use crate::scalar_field::ScalarField;
+    // #[test]
+    // unconstrained fn fuzz_test_scalar_field_conversion(f: Field) {
+    //     let scalar_field: ScalarField<64> = ScalarField::from(f);
+    //     let scalar_field2 = scalar_field.into();
+    //     assert(f == scalar_field2);
+    // }
 }

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -44,7 +44,6 @@ unconstrained fn get_wnaf_slices<let N: u32>(x: Field) -> ([u8; N], bool) {
             result[N - i] -= 8;
         }
     }
-
     (result, skew)
 }
 
@@ -74,7 +73,6 @@ where
             result[N - i] -= 8;
         }
     }
-
     (result, skew)
 }
 
@@ -230,21 +228,29 @@ impl<let N: u32> ScalarField<N> {
             result.set_limb(result.num_limbs() - 1, acc);
         }
         for i in 1..result.num_limbs() {
-            let mut acc: u128 = 0;
+            // Using a Field type to allow for negative numbers.
+            let mut acc: Field = 0;
             for _ in 0..30 {
                 acc = acc * 16;
-                // TODO: this is not correct. Error: attempt to subtract with overflow
-                acc = acc + (self.base4_slices[count] as u128) * 2 - 15;
+                acc = acc + (self.base4_slices[count] as Field) * 2 - 15;
                 count = count + 1;
             }
-            if acc >= 0x1000000000000000000000000000000 {
-                acc += 0x1000000000000000000000000000000;
+            let mut acc_u128: u128 = acc as u128;
+            // Handle negative numbers. If the number is negative, it is greater than 2^120 in Field.
+            // All positive numbers are less than 2^120 in Field.
+            // For example, 42 is -6 + 3 * 2^4 with wnaf algorithm, but it should be 42 = 10 + 2 * 2^4
+            // To get the actual number 10, we need to subtract the number 6 from 2^4.
+            if acc_u128 >= 0x1000000000000000000000000000000 {
+                // find the actual number needed to be subtracted.
+                let reverse = (acc * -1) as u128;
+                acc_u128 = (1 as u128 << 120) - reverse;
+                acc = acc - 0x1000000000000000000000000000000;
                 result.set_limb(
                     result.num_limbs() - i,
                     result.get_limb((result.num_limbs() - i)) - 1,
                 );
             }
-            result.set_limb(result.num_limbs() - 1 - i, acc);
+            result.set_limb(result.num_limbs() - 1 - i, acc_u128);
         }
         result.set_limb(0, result.get_limb(0) - self.skew as u128);
         result
@@ -287,9 +293,20 @@ pub(crate) unconstrained fn extract_nibbles_from_bytes<let N: u32, let M: u32>(
 mod tests {
     use crate::scalar_field::ScalarField;
     #[test]
+    // test even number of nibbles
     unconstrained fn fuzz_test_scalar_field_conversion(f: Field) {
         let scalar_field: ScalarField<64> = ScalarField::from(f);
         let scalar_field2 = scalar_field.into();
         assert(f == scalar_field2);
+    }
+    #[test]
+    // test odd number of nibbles
+    unconstrained fn fuzz_test_scalar_field_conversion2(f: u128) {
+        // 2^124 -1, 31 nibbles
+        let mask_124: u128 = 0x10000000000000000000000000000000 - 1;
+        let val: u128 = f & mask_124;
+        let scalar_field: ScalarField<31> = ScalarField::from(val as Field);
+        let scalar_field2 = scalar_field.into();
+        assert(val as Field == scalar_field2);
     }
 }

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -26,9 +26,9 @@ pub struct ScalarField<let N: u32> {
 // 1, 2, 3, 4
 unconstrained fn get_wnaf_slices<let N: u32>(x: Field) -> ([u8; N], bool) {
     let mut result: [u8; N] = [0; N];
-    let bytes = x.to_le_bytes();
+    let bytes = x.to_le_bytes::<N/2>();
     
-    // Extract nibbles from bytes using helper function
+    // Extract nibbles from bytes
     let mut nibbles: [u8; N] = [0; N];
     nibbles = extract_nibbles_from_bytes(bytes);
 
@@ -56,7 +56,7 @@ where
     let mut nibbles: [[u8; 30]; (N / 30) + 1] = [[0; 30]; (N / 30) + 1];
     let x: [u128] = x.get_limbs().as_slice();
     for i in 0..x.len() {
-        let bytes = (x[i] as Field).to_le_bytes();
+        let bytes = (x[i] as Field).to_le_bytes::<15>();
         nibbles[i] = extract_nibbles_from_bytes(bytes);
     }
 
@@ -266,15 +266,15 @@ unconstrained fn extract_nibbles_from_bytes<let N: u32>(bytes: [u8]) -> [u8; N] 
         if nibble_idx >= N {
             break;
         }
-        // Extract high nibble (bits 4-7)
-        result[nibble_idx] = (bytes[i] >> 4) & 0x0F;
+        // Extract low nibble (bits 0-3)
+        result[nibble_idx] = bytes[i] & 0x0F;
         nibble_idx += 1;
-        
+
         if nibble_idx >= N {
             break;
         }
-        // Extract low nibble (bits 0-3)
-        result[nibble_idx] = bytes[i] & 0x0F;
+        // Extract high nibble (bits 4-7)
+        result[nibble_idx] = (bytes[i] >> 4) & 0x0F;
         nibble_idx += 1;
     }
     


### PR DESCRIPTION
# Description

to_le_radix is no longer exposed, but to_le_bytes is. Use to_le_bytes and bitwise operations to replace to_le_radix.

## Problem\*

Resolves https://github.com/noir-lang/noir_bigcurve/issues/55 and https://github.com/noir-lang/noir_bigcurve/issues/77

## Summary\*



## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
