### PR TITLE
fix: bump bignum v0.7.5

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,5 +5,5 @@ authors = [""]
 compiler_version = ">=1.0.0"
 
 [dependencies]
-bignum = { tag = "v0.7.4", git = "https://github.com/noir-lang/noir-bignum" }
+bignum = { tag = "v0.7.5", git = "https://github.com/noir-lang/noir-bignum" }
 poseidon = { git = "https://github.com/noir-lang/poseidon", tag = "v0.1.1" }


### PR DESCRIPTION
# Description

## Problem

For https://github.com/noir-lang/noir/pull/9295

## Summary

Without this bump, accessing `bignum::bignum` will give a compile error.

## Additional Context



# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
