### PR TITLE
chore: exposing `curves` module

### DIFF
--- a/src/lib.nr
+++ b/src/lib.nr
@@ -3,7 +3,7 @@ mod test_data;
 mod bigcurve_test;
 pub mod scalar_field;
 pub(crate) mod utils;
-pub(crate) mod curves;
+pub mod curves;
 
 use bignum::BigNum;
 use bignum::bignum::evaluate_quadratic_expression;


### PR DESCRIPTION
# Description

When consuming this library in aztec-packages we need the `curves` module exposed:
<img width="660" height="109" alt="image" src="https://github.com/user-attachments/assets/013a67ae-b14d-4839-bdcc-ee7ecc4726fa" />

If it is not supposed to be exposed then we can close this PR and solve it differently. I don't have context on the aztec-packages code that uses it since I've never worked with that piece of codebase.