### PR TITLE
chore!: bump to use `bignum` v0.8.0

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,5 +5,6 @@ authors = [""]
 compiler_version = ">=1.0.0"
 
 [dependencies]
-bignum = { tag = "v0.7.5", git = "https://github.com/noir-lang/noir-bignum" }
+bignum = { tag = "v0.8.0", git = "https://github.com/noir-lang/noir-bignum" }
 poseidon = { git = "https://github.com/noir-lang/poseidon", tag = "v0.1.1" }
+    


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
