### PR TITLE
fix: Update dependencies

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,6 +5,6 @@ authors = [""]
 compiler_version = ">=1.0.0"
 
 [dependencies]
-bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.9.0" }
-poseidon = { git = "https://github.com/noir-lang/poseidon", tag = "v0.2.3" }
+bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.9.1" }
+poseidon = { git = "https://github.com/noir-lang/poseidon", tag = "v0.2.4" }
     


### PR DESCRIPTION
# Description

## Problem\*

Resolves breaking changes from https://github.com/noir-lang/noir/pull/11627 

## Summary\*

Updates poseidon & noir-bignum to versions working with the above Noir compiler change

## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
